### PR TITLE
DAC6-2734: QA issues addressed

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,7 @@
 .js-enabled .js-visible {
   display: inline-block !important;
 }
+.wrappable {
+    display: inline-block;
+    word-break: break-word;
+}

--- a/app/controllers/FirstContactEmailController.scala
+++ b/app/controllers/FirstContactEmailController.scala
@@ -45,6 +45,7 @@ class FirstContactEmailController @Inject() (
     with I18nSupport {
 
   val form = formProvider()
+  val fi   = "Placeholder Financial Institution" // todo: pull in this when available
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
@@ -54,10 +55,10 @@ class FirstContactEmailController @Inject() (
         case None        => form
         case Some(value) => form.fill(value)
       }
-
-      ua.get(ContactNamePage) match {
+      val contactName = ua.get(ContactNamePage)
+      contactName match {
         case None       => Redirect(routes.IndexController.onPageLoad)
-        case Some(name) => Ok(view(preparedForm, mode, name))
+        case Some(name) => Ok(view(preparedForm, mode, fi, name))
       }
   }
 
@@ -72,7 +73,7 @@ class FirstContactEmailController @Inject() (
             form
               .bindFromRequest()
               .fold(
-                formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, name))),
+                formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, fi, name))),
                 value =>
                   for {
                     updatedAnswers <- Future.fromTry(request.userAnswers.set(FirstContactEmailPage, value))

--- a/app/forms/FirstContactEmailFormProvider.scala
+++ b/app/forms/FirstContactEmailFormProvider.scala
@@ -27,7 +27,12 @@ class FirstContactEmailFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("firstContactEmail.error.required")
-        .verifying(firstError(Constraints.emailAddress(errorMessage = "firstContactEmail.error.format"), maxLength(132, "firstContactEmail.error.length")))
+        .verifying(
+          firstError(
+            maxLength(132, "firstContactEmail.error.length"),
+            Constraints.emailAddress(errorMessage = "firstContactEmail.error.format")
+          )
+        )
     )
 
 }

--- a/app/forms/FirstContactEmailFormProvider.scala
+++ b/app/forms/FirstContactEmailFormProvider.scala
@@ -27,8 +27,7 @@ class FirstContactEmailFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("firstContactEmail.error.required")
-        .verifying(maxLength(132, "firstContactEmail.error.length"))
-        .verifying(Constraints.emailAddress(errorMessage = "firstContactEmail.error.format"))
+        .verifying(firstError(Constraints.emailAddress(errorMessage = "firstContactEmail.error.format"), maxLength(132, "firstContactEmail.error.length")))
     )
 
 }

--- a/app/viewmodels/govuk/LabelFluency.scala
+++ b/app/viewmodels/govuk/LabelFluency.scala
@@ -47,6 +47,9 @@ trait LabelFluency {
     def forAttr(attr: String): Label =
       label.copy(forAttr = Some(attr))
 
+    def visuallyHidden(): Label =
+      label.withCssClass("govuk-visually-hidden")
+
   }
 
 }

--- a/app/views/FirstContactEmailView.scala.html
+++ b/app/views/FirstContactEmailView.scala.html
@@ -44,7 +44,7 @@
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("firstContactEmail.heading", name))
+                label = LabelViewModel(messages("firstContactEmail.heading", name)).visuallyHidden()
             )
             .withWidth(Full)
             .asEmail()

--- a/app/views/FirstContactEmailView.scala.html
+++ b/app/views/FirstContactEmailView.scala.html
@@ -15,18 +15,19 @@
  *@
 
 @import viewmodels.InputWidth._
+@import components._
 
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukInput: GovukInput,
-    govukButton: GovukButton
+    govukButton: GovukButton,
+    paragraph: Paragraph,
+    heading: Heading,
 )
 
-@(form: Form[_], mode: Mode, name: String)(implicit request: Request[_], messages: Messages)
-
-@paraContent = {@messages("firstContactEmail.p1", name)}
+@(form: Form[_], mode: Mode, finInstitution: String, name: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("firstContactEmail.title", name))) {
 
@@ -36,15 +37,17 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
+        @heading(messages("firstContactEmail.heading", name))
+
+        @paragraph(Html(messages("firstContactEmail.p1", finInstitution)))
+
         @govukInput(
             InputViewModel(
                 field = form("value"),
-                label = LabelViewModel(messages("firstContactEmail.heading", name)).asPageHeading()
+                label = LabelViewModel(messages("firstContactEmail.heading", name))
             )
             .withWidth(Full)
-            .withHint(Hint(content = HtmlContent(paraContent)))
             .asEmail()
-
         )
 
         @govukButton(

--- a/app/views/components/Heading.scala.html
+++ b/app/views/components/Heading.scala.html
@@ -18,6 +18,4 @@
 
 @(headingContent: String, size: String = "l")
 
-<h1 class="govuk-label-wrapper">
- <label class="govuk-label govuk-label--@size wrappable" >@headingContent</label>
-</h1>
+<h1 class="govuk-heading-@size wrappable" >@headingContent</h1>

--- a/app/views/components/Heading.scala.html
+++ b/app/views/components/Heading.scala.html
@@ -16,7 +16,7 @@
 
 @this()
 
-@(headingContent: String, size: String = "xl")
+@(headingContent: String, size: String = "l")
 
 <h1 class="govuk-label-wrapper">
  <label class="govuk-label govuk-label--@size wrappable" >@headingContent</label>

--- a/app/views/components/Heading.scala.html
+++ b/app/views/components/Heading.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(headingContent: String, size: String = "xl")
+
+<h1 class="govuk-label-wrapper">
+ <label class="govuk-label govuk-label--@size wrappable" >@headingContent</label>
+</h1>

--- a/app/views/components/Paragraph.scala.html
+++ b/app/views/components/Paragraph.scala.html
@@ -1,0 +1,21 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(content: Html, classes: String = "govuk-body", id: Option[String] = None)
+
+<p class="@classes wrappable" @id.map{id => id="@id"}>@content</p>

--- a/test/controllers/FirstContactEmailControllerSpec.scala
+++ b/test/controllers/FirstContactEmailControllerSpec.scala
@@ -42,8 +42,9 @@ class FirstContactEmailControllerSpec extends SpecBase with MockitoSugar {
 
   private lazy val firstContactEmailRoute = routes.FirstContactEmailController.onPageLoad(NormalMode).url
 
-  val contactName = "Mr Test"
-  private val ua  = emptyUserAnswers.set(ContactNamePage, contactName).get
+  val contactName          = "Mr Test"
+  val financialInstitution = "Placeholder Financial Institution"
+  private val ua           = emptyUserAnswers.set(ContactNamePage, contactName).get
 
   "FirstContactEmail Controller" - {
 
@@ -59,7 +60,7 @@ class FirstContactEmailControllerSpec extends SpecBase with MockitoSugar {
         val view = application.injector.instanceOf[FirstContactEmailView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, contactName)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(form, NormalMode, financialInstitution, contactName)(request, messages(application)).toString
       }
     }
 
@@ -77,7 +78,7 @@ class FirstContactEmailControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode, contactName)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode, financialInstitution, contactName)(request, messages(application)).toString
       }
     }
 
@@ -123,7 +124,7 @@ class FirstContactEmailControllerSpec extends SpecBase with MockitoSugar {
         val result = route(application, request).value
 
         status(result) mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, contactName)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(boundForm, NormalMode, financialInstitution, contactName)(request, messages(application)).toString
       }
     }
 


### PR DESCRIPTION
**part1**

1. “We will use this email address to send confirmation of reports for [FI name] or if we have any questions about them.” should be a paragraph instead of hint text. 
2. In the above paragraph, FI name is the Financial Institution Name. Currently “FI first contact name” from url /contact-name is displayed. 
3. In case of Invalid format and Too long errors, Invalid format error is displayed only once. 

**part2**
5. .wrappable class added to service to prevent future audit failures
6. .visuallyHidden added to LabelFluency for pages where paragraphs appear between the heading and the form (unless its a hint it is not supported otherwise)