### PR TITLE
Dac6-2980: Skeleton pages (for Address and GIIN)

### DIFF
--- a/app/controllers/HaveGIINController.scala
+++ b/app/controllers/HaveGIINController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.HaveGIINView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class HaveGIINController @Inject()(
-                                         override val messagesApi: MessagesApi,
-                                         sessionRepository: SessionRepository,
-                                         navigator: Navigator,
-                                         identify: IdentifierAction,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction,
-                                         formProvider: HaveGIINFormProvider,
-                                         val controllerComponents: MessagesControllerComponents,
-                                         view: HaveGIINView
-                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class HaveGIINController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: HaveGIINFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: HaveGIINView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(HaveGIINPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class HaveGIINController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(HaveGIINPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(HaveGIINPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(HaveGIINPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(HaveGIINPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/HaveGIINController.scala
+++ b/app/controllers/HaveGIINController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.HaveGIINFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.HaveGIINPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.HaveGIINView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class HaveGIINController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: HaveGIINFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: HaveGIINView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(HaveGIINPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(HaveGIINPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(HaveGIINPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionLocationController.scala
+++ b/app/controllers/InstitutionLocationController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.InstitutionLocationFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.InstitutionLocationPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.InstitutionLocationView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstitutionLocationController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: InstitutionLocationFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: InstitutionLocationView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(InstitutionLocationPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionLocationPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(InstitutionLocationPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionLocationController.scala
+++ b/app/controllers/InstitutionLocationController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.InstitutionLocationView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InstitutionLocationController @Inject()(
-                                         override val messagesApi: MessagesApi,
-                                         sessionRepository: SessionRepository,
-                                         navigator: Navigator,
-                                         identify: IdentifierAction,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction,
-                                         formProvider: InstitutionLocationFormProvider,
-                                         val controllerComponents: MessagesControllerComponents,
-                                         view: InstitutionLocationView
-                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InstitutionLocationController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: InstitutionLocationFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: InstitutionLocationView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(InstitutionLocationPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class InstitutionLocationController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionLocationPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(InstitutionLocationPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionLocationPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(InstitutionLocationPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/InstitutionPostcodeController.scala
+++ b/app/controllers/InstitutionPostcodeController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.InstitutionPostcodeFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.InstitutionPostcodePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.InstitutionPostcodeView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstitutionPostcodeController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: InstitutionPostcodeFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: InstitutionPostcodeView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(InstitutionPostcodePage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionPostcodePage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(InstitutionPostcodePage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionPostcodeController.scala
+++ b/app/controllers/InstitutionPostcodeController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.InstitutionPostcodeView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InstitutionPostcodeController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: InstitutionPostcodeFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: InstitutionPostcodeView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InstitutionPostcodeController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: InstitutionPostcodeFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: InstitutionPostcodeView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(InstitutionPostcodePage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class InstitutionPostcodeController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionPostcodePage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(InstitutionPostcodePage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionPostcodePage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(InstitutionPostcodePage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/InstitutionSelectAddressController.scala
+++ b/app/controllers/InstitutionSelectAddressController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.InstitutionSelectAddressView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InstitutionSelectAddressController @Inject()(
-                                       override val messagesApi: MessagesApi,
-                                       sessionRepository: SessionRepository,
-                                       navigator: Navigator,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
-                                       formProvider: InstitutionSelectAddressFormProvider,
-                                       val controllerComponents: MessagesControllerComponents,
-                                       view: InstitutionSelectAddressView
-                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InstitutionSelectAddressController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: InstitutionSelectAddressFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: InstitutionSelectAddressView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(InstitutionSelectAddressPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class InstitutionSelectAddressController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectAddressPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(InstitutionSelectAddressPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectAddressPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(InstitutionSelectAddressPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/InstitutionSelectAddressController.scala
+++ b/app/controllers/InstitutionSelectAddressController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.InstitutionSelectAddressFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.InstitutionSelectAddressPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.InstitutionSelectAddressView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstitutionSelectAddressController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       sessionRepository: SessionRepository,
+                                       navigator: Navigator,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       formProvider: InstitutionSelectAddressFormProvider,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: InstitutionSelectAddressView
+                                     )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(InstitutionSelectAddressPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectAddressPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(InstitutionSelectAddressPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionSelectNonUkAddressController.scala
+++ b/app/controllers/InstitutionSelectNonUkAddressController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.InstitutionSelectNonUkAddressFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.InstitutionSelectNonUkAddressPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.InstitutionSelectNonUkAddressView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstitutionSelectNonUkAddressController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: InstitutionSelectNonUkAddressFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: InstitutionSelectNonUkAddressView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(InstitutionSelectNonUkAddressPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectNonUkAddressPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(InstitutionSelectNonUkAddressPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionSelectNonUkAddressController.scala
+++ b/app/controllers/InstitutionSelectNonUkAddressController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.InstitutionSelectNonUkAddressView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InstitutionSelectNonUkAddressController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: InstitutionSelectNonUkAddressFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: InstitutionSelectNonUkAddressView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InstitutionSelectNonUkAddressController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: InstitutionSelectNonUkAddressFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: InstitutionSelectNonUkAddressView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(InstitutionSelectNonUkAddressPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class InstitutionSelectNonUkAddressController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectNonUkAddressPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(InstitutionSelectNonUkAddressPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectNonUkAddressPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(InstitutionSelectNonUkAddressPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/InstitutionSelectUkAddressController.scala
+++ b/app/controllers/InstitutionSelectUkAddressController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.InstitutionSelectUkAddressFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.InstitutionSelectUkAddressPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.InstitutionSelectUkAddressView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class InstitutionSelectUkAddressController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: InstitutionSelectUkAddressFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: InstitutionSelectUkAddressView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(InstitutionSelectUkAddressPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectUkAddressPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(InstitutionSelectUkAddressPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/InstitutionSelectUkAddressController.scala
+++ b/app/controllers/InstitutionSelectUkAddressController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.InstitutionSelectUkAddressView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class InstitutionSelectUkAddressController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: InstitutionSelectUkAddressFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: InstitutionSelectUkAddressView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class InstitutionSelectUkAddressController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: InstitutionSelectUkAddressFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: InstitutionSelectUkAddressView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(InstitutionSelectUkAddressPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class InstitutionSelectUkAddressController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectUkAddressPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(InstitutionSelectUkAddressPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(InstitutionSelectUkAddressPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(InstitutionSelectUkAddressPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/IsThisInstitutionAddressController.scala
+++ b/app/controllers/IsThisInstitutionAddressController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.IsThisInstitutionAddressFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.IsThisInstitutionAddressPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.IsThisInstitutionAddressView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class IsThisInstitutionAddressController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: IsThisInstitutionAddressFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: IsThisInstitutionAddressView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(IsThisInstitutionAddressPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisInstitutionAddressPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(IsThisInstitutionAddressPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/IsThisInstitutionAddressController.scala
+++ b/app/controllers/IsThisInstitutionAddressController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.IsThisInstitutionAddressView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class IsThisInstitutionAddressController @Inject()(
-                                         override val messagesApi: MessagesApi,
-                                         sessionRepository: SessionRepository,
-                                         navigator: Navigator,
-                                         identify: IdentifierAction,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction,
-                                         formProvider: IsThisInstitutionAddressFormProvider,
-                                         val controllerComponents: MessagesControllerComponents,
-                                         view: IsThisInstitutionAddressView
-                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class IsThisInstitutionAddressController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: IsThisInstitutionAddressFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: IsThisInstitutionAddressView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(IsThisInstitutionAddressPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class IsThisInstitutionAddressController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisInstitutionAddressPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(IsThisInstitutionAddressPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisInstitutionAddressPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(IsThisInstitutionAddressPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/SendReportsController.scala
+++ b/app/controllers/SendReportsController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.SendReportsView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SendReportsController @Inject()(
-                                         override val messagesApi: MessagesApi,
-                                         sessionRepository: SessionRepository,
-                                         navigator: Navigator,
-                                         identify: IdentifierAction,
-                                         getData: DataRetrievalAction,
-                                         requireData: DataRequiredAction,
-                                         formProvider: SendReportsFormProvider,
-                                         val controllerComponents: MessagesControllerComponents,
-                                         view: SendReportsView
-                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class SendReportsController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: SendReportsFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: SendReportsView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(SendReportsPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class SendReportsController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(SendReportsPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(SendReportsPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(SendReportsPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(SendReportsPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/SendReportsController.scala
+++ b/app/controllers/SendReportsController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.SendReportsFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.SendReportsPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.SendReportsView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SendReportsController @Inject()(
+                                         override val messagesApi: MessagesApi,
+                                         sessionRepository: SessionRepository,
+                                         navigator: Navigator,
+                                         identify: IdentifierAction,
+                                         getData: DataRetrievalAction,
+                                         requireData: DataRequiredAction,
+                                         formProvider: SendReportsFormProvider,
+                                         val controllerComponents: MessagesControllerComponents,
+                                         view: SendReportsView
+                                 )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(SendReportsPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(SendReportsPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(SendReportsPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/controllers/WhatIsGIINController.scala
+++ b/app/controllers/WhatIsGIINController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -14,25 +30,26 @@ import views.html.WhatIsGIINView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class WhatIsGIINController @Inject()(
-                                        override val messagesApi: MessagesApi,
-                                        sessionRepository: SessionRepository,
-                                        navigator: Navigator,
-                                        identify: IdentifierAction,
-                                        getData: DataRetrievalAction,
-                                        requireData: DataRequiredAction,
-                                        formProvider: WhatIsGIINFormProvider,
-                                        val controllerComponents: MessagesControllerComponents,
-                                        view: WhatIsGIINView
-                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+class WhatIsGIINController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  formProvider: WhatIsGIINFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: WhatIsGIINView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
 
   val form = formProvider()
 
   def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-
       val preparedForm = request.userAnswers.get(WhatIsGIINPage) match {
-        case None => form
+        case None        => form
         case Some(value) => form.fill(value)
       }
 
@@ -41,16 +58,16 @@ class WhatIsGIINController @Inject()(
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-
-      form.bindFromRequest().fold(
-        formWithErrors =>
-          Future.successful(BadRequest(view(formWithErrors, mode))),
-
-        value =>
-          for {
-            updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsGIINPage, value))
-            _              <- sessionRepository.set(updatedAnswers)
-          } yield Redirect(navigator.nextPage(WhatIsGIINPage, mode, updatedAnswers))
-      )
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsGIINPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(WhatIsGIINPage, mode, updatedAnswers))
+        )
   }
+
 }

--- a/app/controllers/WhatIsGIINController.scala
+++ b/app/controllers/WhatIsGIINController.scala
@@ -1,0 +1,56 @@
+package controllers
+
+import controllers.actions._
+import forms.WhatIsGIINFormProvider
+import javax.inject.Inject
+import models.Mode
+import navigation.Navigator
+import pages.WhatIsGIINPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.WhatIsGIINView
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class WhatIsGIINController @Inject()(
+                                        override val messagesApi: MessagesApi,
+                                        sessionRepository: SessionRepository,
+                                        navigator: Navigator,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        requireData: DataRequiredAction,
+                                        formProvider: WhatIsGIINFormProvider,
+                                        val controllerComponents: MessagesControllerComponents,
+                                        view: WhatIsGIINView
+                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport {
+
+  val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+
+      val preparedForm = request.userAnswers.get(WhatIsGIINPage) match {
+        case None => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
+    implicit request =>
+
+      form.bindFromRequest().fold(
+        formWithErrors =>
+          Future.successful(BadRequest(view(formWithErrors, mode))),
+
+        value =>
+          for {
+            updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsGIINPage, value))
+            _              <- sessionRepository.set(updatedAnswers)
+          } yield Redirect(navigator.nextPage(WhatIsGIINPage, mode, updatedAnswers))
+      )
+  }
+}

--- a/app/forms/HaveGIINFormProvider.scala
+++ b/app/forms/HaveGIINFormProvider.scala
@@ -1,0 +1,14 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class HaveGIINFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("haveGIIN.error.required")
+    )
+}

--- a/app/forms/HaveGIINFormProvider.scala
+++ b/app/forms/HaveGIINFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -11,4 +27,5 @@ class HaveGIINFormProvider @Inject() extends Mappings {
     Form(
       "value" -> boolean("haveGIIN.error.required")
     )
+
 }

--- a/app/forms/InstitutionLocationFormProvider.scala
+++ b/app/forms/InstitutionLocationFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -11,4 +27,5 @@ class InstitutionLocationFormProvider @Inject() extends Mappings {
     Form(
       "value" -> boolean("institutionLocation.error.required")
     )
+
 }

--- a/app/forms/InstitutionLocationFormProvider.scala
+++ b/app/forms/InstitutionLocationFormProvider.scala
@@ -1,0 +1,14 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class InstitutionLocationFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("institutionLocation.error.required")
+    )
+}

--- a/app/forms/InstitutionPostcodeFormProvider.scala
+++ b/app/forms/InstitutionPostcodeFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -12,4 +28,5 @@ class InstitutionPostcodeFormProvider @Inject() extends Mappings {
       "value" -> text("institutionPostcode.error.required")
         .verifying(maxLength(10, "institutionPostcode.error.length"))
     )
+
 }

--- a/app/forms/InstitutionPostcodeFormProvider.scala
+++ b/app/forms/InstitutionPostcodeFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class InstitutionPostcodeFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("institutionPostcode.error.required")
+        .verifying(maxLength(10, "institutionPostcode.error.length"))
+    )
+}

--- a/app/forms/InstitutionSelectAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectAddressFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+import models.InstitutionSelectAddress
+
+class InstitutionSelectAddressFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[InstitutionSelectAddress] =
+    Form(
+      "value" -> enumerable[InstitutionSelectAddress]("institutionSelectAddress.error.required")
+    )
+}

--- a/app/forms/InstitutionSelectAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectAddressFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -12,4 +28,5 @@ class InstitutionSelectAddressFormProvider @Inject() extends Mappings {
     Form(
       "value" -> enumerable[InstitutionSelectAddress]("institutionSelectAddress.error.required")
     )
+
 }

--- a/app/forms/InstitutionSelectNonUkAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectNonUkAddressFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class InstitutionSelectNonUkAddressFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("institutionSelectNonUkAddress.error.required")
+        .verifying(maxLength(100, "institutionSelectNonUkAddress.error.length"))
+    )
+}

--- a/app/forms/InstitutionSelectNonUkAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectNonUkAddressFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -12,4 +28,5 @@ class InstitutionSelectNonUkAddressFormProvider @Inject() extends Mappings {
       "value" -> text("institutionSelectNonUkAddress.error.required")
         .verifying(maxLength(100, "institutionSelectNonUkAddress.error.length"))
     )
+
 }

--- a/app/forms/InstitutionSelectUkAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectUkAddressFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -12,4 +28,5 @@ class InstitutionSelectUkAddressFormProvider @Inject() extends Mappings {
       "value" -> text("institutionSelectUkAddress.error.required")
         .verifying(maxLength(100, "institutionSelectUkAddress.error.length"))
     )
+
 }

--- a/app/forms/InstitutionSelectUkAddressFormProvider.scala
+++ b/app/forms/InstitutionSelectUkAddressFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class InstitutionSelectUkAddressFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("institutionSelectUkAddress.error.required")
+        .verifying(maxLength(100, "institutionSelectUkAddress.error.length"))
+    )
+}

--- a/app/forms/IsThisInstitutionAddressFormProvider.scala
+++ b/app/forms/IsThisInstitutionAddressFormProvider.scala
@@ -1,0 +1,14 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class IsThisInstitutionAddressFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("isThisInstitutionAddress.error.required")
+    )
+}

--- a/app/forms/IsThisInstitutionAddressFormProvider.scala
+++ b/app/forms/IsThisInstitutionAddressFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -11,4 +27,5 @@ class IsThisInstitutionAddressFormProvider @Inject() extends Mappings {
     Form(
       "value" -> boolean("isThisInstitutionAddress.error.required")
     )
+
 }

--- a/app/forms/SendReportsFormProvider.scala
+++ b/app/forms/SendReportsFormProvider.scala
@@ -1,0 +1,14 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class SendReportsFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("sendReports.error.required")
+    )
+}

--- a/app/forms/SendReportsFormProvider.scala
+++ b/app/forms/SendReportsFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -11,4 +27,5 @@ class SendReportsFormProvider @Inject() extends Mappings {
     Form(
       "value" -> boolean("sendReports.error.required")
     )
+
 }

--- a/app/forms/WhatIsGIINFormProvider.scala
+++ b/app/forms/WhatIsGIINFormProvider.scala
@@ -1,0 +1,15 @@
+package forms
+
+import javax.inject.Inject
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+class WhatIsGIINFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> text("whatIsGIIN.error.required")
+        .verifying(maxLength(100, "whatIsGIIN.error.length"))
+    )
+}

--- a/app/forms/WhatIsGIINFormProvider.scala
+++ b/app/forms/WhatIsGIINFormProvider.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import javax.inject.Inject
@@ -12,4 +28,5 @@ class WhatIsGIINFormProvider @Inject() extends Mappings {
       "value" -> text("whatIsGIIN.error.required")
         .verifying(maxLength(100, "whatIsGIIN.error.length"))
     )
+
 }

--- a/app/models/InstitutionSelectAddress.scala
+++ b/app/models/InstitutionSelectAddress.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import play.api.i18n.Messages
@@ -12,18 +28,24 @@ object InstitutionSelectAddress extends Enumerable.Implicits {
   case object Address2 extends WithName("address2") with InstitutionSelectAddress
 
   val values: Seq[InstitutionSelectAddress] = Seq(
-    Address1, Address2
+    Address1,
+    Address2
   )
 
   def options(implicit messages: Messages): Seq[RadioItem] = values.zipWithIndex.map {
     case (value, index) =>
       RadioItem(
         content = Text(messages(s"institutionSelectAddress.${value.toString}")),
-        value   = Some(value.toString),
-        id      = Some(s"value_$index")
+        value = Some(value.toString),
+        id = Some(s"value_$index")
       )
   }
 
   implicit val enumerable: Enumerable[InstitutionSelectAddress] =
-    Enumerable(values.map(v => v.toString -> v): _*)
+    Enumerable(
+      values.map(
+        v => v.toString -> v
+      ): _*
+    )
+
 }

--- a/app/models/InstitutionSelectAddress.scala
+++ b/app/models/InstitutionSelectAddress.scala
@@ -1,0 +1,29 @@
+package models
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+
+sealed trait InstitutionSelectAddress
+
+object InstitutionSelectAddress extends Enumerable.Implicits {
+
+  case object Address1 extends WithName("address1") with InstitutionSelectAddress
+  case object Address2 extends WithName("address2") with InstitutionSelectAddress
+
+  val values: Seq[InstitutionSelectAddress] = Seq(
+    Address1, Address2
+  )
+
+  def options(implicit messages: Messages): Seq[RadioItem] = values.zipWithIndex.map {
+    case (value, index) =>
+      RadioItem(
+        content = Text(messages(s"institutionSelectAddress.${value.toString}")),
+        value   = Some(value.toString),
+        id      = Some(s"value_$index")
+      )
+  }
+
+  implicit val enumerable: Enumerable[InstitutionSelectAddress] =
+    Enumerable(values.map(v => v.toString -> v): _*)
+}

--- a/app/pages/HaveGIINPage.scala
+++ b/app/pages/HaveGIINPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/HaveGIINPage.scala
+++ b/app/pages/HaveGIINPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object HaveGIINPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "haveGIIN"
+}

--- a/app/pages/InstitutionLocationPage.scala
+++ b/app/pages/InstitutionLocationPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/InstitutionLocationPage.scala
+++ b/app/pages/InstitutionLocationPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object InstitutionLocationPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "institutionLocation"
+}

--- a/app/pages/InstitutionPostcodePage.scala
+++ b/app/pages/InstitutionPostcodePage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/InstitutionPostcodePage.scala
+++ b/app/pages/InstitutionPostcodePage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object InstitutionPostcodePage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "institutionPostcode"
+}

--- a/app/pages/InstitutionSelectAddressPage.scala
+++ b/app/pages/InstitutionSelectAddressPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import models.InstitutionSelectAddress

--- a/app/pages/InstitutionSelectAddressPage.scala
+++ b/app/pages/InstitutionSelectAddressPage.scala
@@ -1,0 +1,11 @@
+package pages
+
+import models.InstitutionSelectAddress
+import play.api.libs.json.JsPath
+
+case object InstitutionSelectAddressPage extends QuestionPage[InstitutionSelectAddress] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "institutionSelectAddress"
+}

--- a/app/pages/InstitutionSelectNonUkAddressPage.scala
+++ b/app/pages/InstitutionSelectNonUkAddressPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/InstitutionSelectNonUkAddressPage.scala
+++ b/app/pages/InstitutionSelectNonUkAddressPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object InstitutionSelectNonUkAddressPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "institutionSelectNonUkAddress"
+}

--- a/app/pages/InstitutionSelectUkAddressPage.scala
+++ b/app/pages/InstitutionSelectUkAddressPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/InstitutionSelectUkAddressPage.scala
+++ b/app/pages/InstitutionSelectUkAddressPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object InstitutionSelectUkAddressPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "institutionSelectUkAddress"
+}

--- a/app/pages/IsThisInstitutionAddressPage.scala
+++ b/app/pages/IsThisInstitutionAddressPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/IsThisInstitutionAddressPage.scala
+++ b/app/pages/IsThisInstitutionAddressPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object IsThisInstitutionAddressPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "isThisInstitutionAddress"
+}

--- a/app/pages/SendReportsPage.scala
+++ b/app/pages/SendReportsPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/SendReportsPage.scala
+++ b/app/pages/SendReportsPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object SendReportsPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "sendReports"
+}

--- a/app/pages/WhatIsGIINPage.scala
+++ b/app/pages/WhatIsGIINPage.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pages
 
 import play.api.libs.json.JsPath

--- a/app/pages/WhatIsGIINPage.scala
+++ b/app/pages/WhatIsGIINPage.scala
@@ -1,0 +1,10 @@
+package pages
+
+import play.api.libs.json.JsPath
+
+case object WhatIsGIINPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "whatIsGIIN"
+}

--- a/app/viewmodels/checkAnswers/HaveGIINSummary.scala
+++ b/app/viewmodels/checkAnswers/HaveGIINSummary.scala
@@ -1,0 +1,28 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.HaveGIINPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object HaveGIINSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(HaveGIINPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "haveGIIN.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.HaveGIINController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("haveGIIN.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/HaveGIINSummary.scala
+++ b/app/viewmodels/checkAnswers/HaveGIINSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -8,21 +24,21 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object HaveGIINSummary  {
+object HaveGIINSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(HaveGIINPage).map {
       answer =>
-
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "haveGIIN.checkYourAnswersLabel",
-          value   = ValueViewModel(value),
+          key = "haveGIIN.checkYourAnswersLabel",
+          value = ValueViewModel(value),
           actions = Seq(
             ActionItemViewModel("site.change", routes.HaveGIINController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("haveGIIN.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/InstitutionLocationSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionLocationSummary.scala
@@ -1,0 +1,28 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.InstitutionLocationPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object InstitutionLocationSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(InstitutionLocationPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "institutionLocation.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.InstitutionLocationController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("institutionLocation.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/InstitutionLocationSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionLocationSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -8,21 +24,21 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object InstitutionLocationSummary  {
+object InstitutionLocationSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(InstitutionLocationPage).map {
       answer =>
-
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "institutionLocation.checkYourAnswersLabel",
-          value   = ValueViewModel(value),
+          key = "institutionLocation.checkYourAnswersLabel",
+          value = ValueViewModel(value),
           actions = Seq(
             ActionItemViewModel("site.change", routes.InstitutionLocationController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("institutionLocation.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/InstitutionPostcodeSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionPostcodeSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -9,19 +25,19 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object InstitutionPostcodeSummary  {
+object InstitutionPostcodeSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(InstitutionPostcodePage).map {
       answer =>
-
         SummaryListRowViewModel(
-          key     = "institutionPostcode.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key = "institutionPostcode.checkYourAnswersLabel",
+          value = ValueViewModel(HtmlFormat.escape(answer).toString),
           actions = Seq(
             ActionItemViewModel("site.change", routes.InstitutionPostcodeController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("institutionPostcode.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/InstitutionPostcodeSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionPostcodeSummary.scala
@@ -1,0 +1,27 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.InstitutionPostcodePage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object InstitutionPostcodeSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(InstitutionPostcodePage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "institutionPostcode.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.InstitutionPostcodeController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("institutionPostcode.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/InstitutionSelectAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectAddressSummary.scala
@@ -1,0 +1,34 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.InstitutionSelectAddressPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object InstitutionSelectAddressSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(InstitutionSelectAddressPage).map {
+      answer =>
+
+        val value = ValueViewModel(
+          HtmlContent(
+            HtmlFormat.escape(messages(s"institutionSelectAddress.$answer"))
+          )
+        )
+
+        SummaryListRowViewModel(
+          key     = "institutionSelectAddress.checkYourAnswersLabel",
+          value   = value,
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.InstitutionSelectAddressController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("institutionSelectAddress.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/InstitutionSelectAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectAddressSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -10,12 +26,11 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object InstitutionSelectAddressSummary  {
+object InstitutionSelectAddressSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(InstitutionSelectAddressPage).map {
       answer =>
-
         val value = ValueViewModel(
           HtmlContent(
             HtmlFormat.escape(messages(s"institutionSelectAddress.$answer"))
@@ -23,12 +38,13 @@ object InstitutionSelectAddressSummary  {
         )
 
         SummaryListRowViewModel(
-          key     = "institutionSelectAddress.checkYourAnswersLabel",
-          value   = value,
+          key = "institutionSelectAddress.checkYourAnswersLabel",
+          value = value,
           actions = Seq(
             ActionItemViewModel("site.change", routes.InstitutionSelectAddressController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("institutionSelectAddress.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/InstitutionSelectNonUkAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectNonUkAddressSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -9,19 +25,19 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object InstitutionSelectNonUkAddressSummary  {
+object InstitutionSelectNonUkAddressSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(InstitutionSelectNonUkAddressPage).map {
       answer =>
-
         SummaryListRowViewModel(
-          key     = "institutionSelectNonUkAddress.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key = "institutionSelectNonUkAddress.checkYourAnswersLabel",
+          value = ValueViewModel(HtmlFormat.escape(answer).toString),
           actions = Seq(
             ActionItemViewModel("site.change", routes.InstitutionSelectNonUkAddressController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("institutionSelectNonUkAddress.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/InstitutionSelectNonUkAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectNonUkAddressSummary.scala
@@ -1,0 +1,27 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.InstitutionSelectNonUkAddressPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object InstitutionSelectNonUkAddressSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(InstitutionSelectNonUkAddressPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "institutionSelectNonUkAddress.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.InstitutionSelectNonUkAddressController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("institutionSelectNonUkAddress.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/InstitutionSelectUkAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectUkAddressSummary.scala
@@ -1,0 +1,27 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.InstitutionSelectUkAddressPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object InstitutionSelectUkAddressSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(InstitutionSelectUkAddressPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "institutionSelectUkAddress.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.InstitutionSelectUkAddressController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("institutionSelectUkAddress.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/InstitutionSelectUkAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/InstitutionSelectUkAddressSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -9,19 +25,19 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object InstitutionSelectUkAddressSummary  {
+object InstitutionSelectUkAddressSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(InstitutionSelectUkAddressPage).map {
       answer =>
-
         SummaryListRowViewModel(
-          key     = "institutionSelectUkAddress.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key = "institutionSelectUkAddress.checkYourAnswersLabel",
+          value = ValueViewModel(HtmlFormat.escape(answer).toString),
           actions = Seq(
             ActionItemViewModel("site.change", routes.InstitutionSelectUkAddressController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("institutionSelectUkAddress.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/IsThisInstitutionAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/IsThisInstitutionAddressSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -8,21 +24,21 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object IsThisInstitutionAddressSummary  {
+object IsThisInstitutionAddressSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(IsThisInstitutionAddressPage).map {
       answer =>
-
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "isThisInstitutionAddress.checkYourAnswersLabel",
-          value   = ValueViewModel(value),
+          key = "isThisInstitutionAddress.checkYourAnswersLabel",
+          value = ValueViewModel(value),
           actions = Seq(
             ActionItemViewModel("site.change", routes.IsThisInstitutionAddressController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("isThisInstitutionAddress.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/IsThisInstitutionAddressSummary.scala
+++ b/app/viewmodels/checkAnswers/IsThisInstitutionAddressSummary.scala
@@ -1,0 +1,28 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.IsThisInstitutionAddressPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object IsThisInstitutionAddressSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(IsThisInstitutionAddressPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "isThisInstitutionAddress.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.IsThisInstitutionAddressController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("isThisInstitutionAddress.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/SendReportsSummary.scala
+++ b/app/viewmodels/checkAnswers/SendReportsSummary.scala
@@ -1,0 +1,28 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.SendReportsPage
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object SendReportsSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(SendReportsPage).map {
+      answer =>
+
+        val value = if (answer) "site.yes" else "site.no"
+
+        SummaryListRowViewModel(
+          key     = "sendReports.checkYourAnswersLabel",
+          value   = ValueViewModel(value),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.SendReportsController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("sendReports.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/SendReportsSummary.scala
+++ b/app/viewmodels/checkAnswers/SendReportsSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -8,21 +24,21 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object SendReportsSummary  {
+object SendReportsSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(SendReportsPage).map {
       answer =>
-
         val value = if (answer) "site.yes" else "site.no"
 
         SummaryListRowViewModel(
-          key     = "sendReports.checkYourAnswersLabel",
-          value   = ValueViewModel(value),
+          key = "sendReports.checkYourAnswersLabel",
+          value = ValueViewModel(value),
           actions = Seq(
             ActionItemViewModel("site.change", routes.SendReportsController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("sendReports.change.hidden"))
           )
         )
     }
+
 }

--- a/app/viewmodels/checkAnswers/WhatIsGIINSummary.scala
+++ b/app/viewmodels/checkAnswers/WhatIsGIINSummary.scala
@@ -1,0 +1,27 @@
+package viewmodels.checkAnswers
+
+import controllers.routes
+import models.{CheckMode, UserAnswers}
+import pages.WhatIsGIINPage
+import play.api.i18n.Messages
+import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
+import viewmodels.govuk.summarylist._
+import viewmodels.implicits._
+
+object WhatIsGIINSummary  {
+
+  def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
+    answers.get(WhatIsGIINPage).map {
+      answer =>
+
+        SummaryListRowViewModel(
+          key     = "whatIsGIIN.checkYourAnswersLabel",
+          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          actions = Seq(
+            ActionItemViewModel("site.change", routes.WhatIsGIINController.onPageLoad(CheckMode).url)
+              .withVisuallyHiddenText(messages("whatIsGIIN.change.hidden"))
+          )
+        )
+    }
+}

--- a/app/viewmodels/checkAnswers/WhatIsGIINSummary.scala
+++ b/app/viewmodels/checkAnswers/WhatIsGIINSummary.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package viewmodels.checkAnswers
 
 import controllers.routes
@@ -9,19 +25,19 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import viewmodels.govuk.summarylist._
 import viewmodels.implicits._
 
-object WhatIsGIINSummary  {
+object WhatIsGIINSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(WhatIsGIINPage).map {
       answer =>
-
         SummaryListRowViewModel(
-          key     = "whatIsGIIN.checkYourAnswersLabel",
-          value   = ValueViewModel(HtmlFormat.escape(answer).toString),
+          key = "whatIsGIIN.checkYourAnswersLabel",
+          value = ValueViewModel(HtmlFormat.escape(answer).toString),
           actions = Seq(
             ActionItemViewModel("site.change", routes.WhatIsGIINController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("whatIsGIIN.change.hidden"))
           )
         )
     }
+
 }

--- a/app/views/HaveGIINView.scala.html
+++ b/app/views/HaveGIINView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,

--- a/app/views/HaveGIINView.scala.html
+++ b/app/views/HaveGIINView.scala.html
@@ -1,0 +1,30 @@
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("haveGIIN.title"))) {
+
+    @formHelper(action = routes.HaveGIINController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("haveGIIN.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/InstitutionLocationView.scala.html
+++ b/app/views/InstitutionLocationView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,

--- a/app/views/InstitutionLocationView.scala.html
+++ b/app/views/InstitutionLocationView.scala.html
@@ -1,0 +1,30 @@
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("institutionLocation.title"))) {
+
+    @formHelper(action = routes.InstitutionLocationController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("institutionLocation.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/InstitutionPostcodeView.scala.html
+++ b/app/views/InstitutionPostcodeView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 
 @this(

--- a/app/views/InstitutionPostcodeView.scala.html
+++ b/app/views/InstitutionPostcodeView.scala.html
@@ -1,0 +1,33 @@
+@import viewmodels.InputWidth._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("institutionPostcode.title"))) {
+
+    @formHelper(action = routes.InstitutionPostcodeController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("institutionPostcode.heading")).asPageHeading()
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/InstitutionSelectAddressView.scala.html
+++ b/app/views/InstitutionSelectAddressView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,

--- a/app/views/InstitutionSelectAddressView.scala.html
+++ b/app/views/InstitutionSelectAddressView.scala.html
@@ -1,0 +1,31 @@
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("institutionSelectAddress.title"))) {
+
+    @formHelper(action = routes.InstitutionSelectAddressController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))
+        }
+
+        @govukRadios(
+            RadiosViewModel(
+                field  = form("value"),
+                legend = LegendViewModel(messages("institutionSelectAddress.heading")).asPageHeading(),
+                items  = InstitutionSelectAddress.options
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/InstitutionSelectNonUkAddressView.scala.html
+++ b/app/views/InstitutionSelectNonUkAddressView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 
 @this(

--- a/app/views/InstitutionSelectNonUkAddressView.scala.html
+++ b/app/views/InstitutionSelectNonUkAddressView.scala.html
@@ -1,0 +1,33 @@
+@import viewmodels.InputWidth._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("institutionSelectNonUkAddress.title"))) {
+
+    @formHelper(action = routes.InstitutionSelectNonUkAddressController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("institutionSelectNonUkAddress.heading")).asPageHeading()
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/InstitutionSelectUkAddressView.scala.html
+++ b/app/views/InstitutionSelectUkAddressView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 
 @this(

--- a/app/views/InstitutionSelectUkAddressView.scala.html
+++ b/app/views/InstitutionSelectUkAddressView.scala.html
@@ -1,0 +1,33 @@
+@import viewmodels.InputWidth._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("institutionSelectUkAddress.title"))) {
+
+    @formHelper(action = routes.InstitutionSelectUkAddressController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("institutionSelectUkAddress.heading")).asPageHeading()
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/IsThisInstitutionAddressView.scala.html
+++ b/app/views/IsThisInstitutionAddressView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,

--- a/app/views/IsThisInstitutionAddressView.scala.html
+++ b/app/views/IsThisInstitutionAddressView.scala.html
@@ -1,0 +1,30 @@
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("isThisInstitutionAddress.title"))) {
+
+    @formHelper(action = routes.IsThisInstitutionAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("isThisInstitutionAddress.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/SendReportsView.scala.html
+++ b/app/views/SendReportsView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,

--- a/app/views/SendReportsView.scala.html
+++ b/app/views/SendReportsView.scala.html
@@ -1,0 +1,30 @@
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("sendReports.title"))) {
+
+    @formHelper(action = routes.SendReportsController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("sendReports.heading")).asPageHeading()
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/WhatIsGIINView.scala.html
+++ b/app/views/WhatIsGIINView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 
 @this(

--- a/app/views/WhatIsGIINView.scala.html
+++ b/app/views/WhatIsGIINView.scala.html
@@ -1,0 +1,33 @@
+@import viewmodels.InputWidth._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("whatIsGIIN.title"))) {
+
+    @formHelper(action = routes.WhatIsGIINController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("whatIsGIIN.heading")).asPageHeading()
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -85,3 +85,48 @@ POST       /whatIsUniqueTaxpayerReference                        controllers.Wha
 GET        /changeWhatIsUniqueTaxpayerReference                  controllers.WhatIsUniqueTaxpayerReferenceController.onPageLoad(mode: Mode = CheckMode)
 POST       /changeWhatIsUniqueTaxpayerReference                  controllers.WhatIsUniqueTaxpayerReferenceController.onSubmit(mode: Mode = CheckMode)
 
+
+GET        /haveGIIN                        controllers.HaveGIINController.onPageLoad(mode: Mode = NormalMode)
+POST       /haveGIIN                        controllers.HaveGIINController.onSubmit(mode: Mode = NormalMode)
+GET        /changeHaveGIIN                  controllers.HaveGIINController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeHaveGIIN                  controllers.HaveGIINController.onSubmit(mode: Mode = CheckMode)
+
+GET        /institutionLocation                        controllers.InstitutionLocationController.onPageLoad(mode: Mode = NormalMode)
+POST       /institutionLocation                        controllers.InstitutionLocationController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInstitutionLocation                  controllers.InstitutionLocationController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInstitutionLocation                  controllers.InstitutionLocationController.onSubmit(mode: Mode = CheckMode)
+
+GET        /institutionPostcode                        controllers.InstitutionPostcodeController.onPageLoad(mode: Mode = NormalMode)
+POST       /institutionPostcode                        controllers.InstitutionPostcodeController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInstitutionPostcode                  controllers.InstitutionPostcodeController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInstitutionPostcode                  controllers.InstitutionPostcodeController.onSubmit(mode: Mode = CheckMode)
+
+GET        /institutionSelectAddress                        controllers.InstitutionSelectAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /institutionSelectAddress                        controllers.InstitutionSelectAddressController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInstitutionSelectAddress                  controllers.InstitutionSelectAddressController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInstitutionSelectAddress                  controllers.InstitutionSelectAddressController.onSubmit(mode: Mode = CheckMode)
+
+GET        /institutionSelectNonUkAddress                        controllers.InstitutionSelectNonUkAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /institutionSelectNonUkAddress                        controllers.InstitutionSelectNonUkAddressController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInstitutionSelectNonUkAddress                  controllers.InstitutionSelectNonUkAddressController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInstitutionSelectNonUkAddress                  controllers.InstitutionSelectNonUkAddressController.onSubmit(mode: Mode = CheckMode)
+
+GET        /institutionSelectUkAddress                        controllers.InstitutionSelectUkAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /institutionSelectUkAddress                        controllers.InstitutionSelectUkAddressController.onSubmit(mode: Mode = NormalMode)
+GET        /changeInstitutionSelectUkAddress                  controllers.InstitutionSelectUkAddressController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeInstitutionSelectUkAddress                  controllers.InstitutionSelectUkAddressController.onSubmit(mode: Mode = CheckMode)
+
+GET        /isThisInstitutionAddress                        controllers.IsThisInstitutionAddressController.onPageLoad(mode: Mode = NormalMode)
+POST       /isThisInstitutionAddress                        controllers.IsThisInstitutionAddressController.onSubmit(mode: Mode = NormalMode)
+GET        /changeIsThisInstitutionAddress                  controllers.IsThisInstitutionAddressController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeIsThisInstitutionAddress                  controllers.IsThisInstitutionAddressController.onSubmit(mode: Mode = CheckMode)
+
+GET        /sendReports                        controllers.SendReportsController.onPageLoad(mode: Mode = NormalMode)
+POST       /sendReports                        controllers.SendReportsController.onSubmit(mode: Mode = NormalMode)
+GET        /changeSendReports                  controllers.SendReportsController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeSendReports                  controllers.SendReportsController.onSubmit(mode: Mode = CheckMode)
+
+GET        /whatIsGIIN                        controllers.WhatIsGIINController.onPageLoad(mode: Mode = NormalMode)
+POST       /whatIsGIIN                        controllers.WhatIsGIINController.onSubmit(mode: Mode = NormalMode)
+GET        /changeWhatIsGIIN                  controllers.WhatIsGIINController.onPageLoad(mode: Mode = CheckMode)
+POST       /changeWhatIsGIIN                  controllers.WhatIsGIINController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -149,3 +149,63 @@ whatIsUniqueTaxpayerReference.error.required = Enter whatIsUniqueTaxpayerReferen
 whatIsUniqueTaxpayerReference.error.length = WhatIsUniqueTaxpayerReference must be 100 characters or less
 whatIsUniqueTaxpayerReference.change.hidden = WhatIsUniqueTaxpayerReference
 
+
+haveGIIN.title = haveGIIN
+haveGIIN.heading = haveGIIN
+haveGIIN.checkYourAnswersLabel = haveGIIN
+haveGIIN.error.required = Select yes if haveGIIN
+haveGIIN.change.hidden = HaveGIIN
+
+institutionLocation.title = institutionLocation
+institutionLocation.heading = institutionLocation
+institutionLocation.checkYourAnswersLabel = institutionLocation
+institutionLocation.error.required = Select yes if institutionLocation
+institutionLocation.change.hidden = InstitutionLocation
+
+institutionPostcode.title = institutionPostcode
+institutionPostcode.heading = institutionPostcode
+institutionPostcode.checkYourAnswersLabel = institutionPostcode
+institutionPostcode.error.required = Enter institutionPostcode
+institutionPostcode.error.length = InstitutionPostcode must be 10 characters or less
+institutionPostcode.change.hidden = InstitutionPostcode
+
+institutionSelectAddress.title = address1
+institutionSelectAddress.heading = address1
+institutionSelectAddress.address1 = address1
+institutionSelectAddress.address2 = address2
+institutionSelectAddress.checkYourAnswersLabel = address1
+institutionSelectAddress.error.required = Select institutionSelectAddress
+institutionSelectAddress.change.hidden = InstitutionSelectAddress
+
+institutionSelectNonUkAddress.title = institutionSelectNonUkAddress
+institutionSelectNonUkAddress.heading = institutionSelectNonUkAddress
+institutionSelectNonUkAddress.checkYourAnswersLabel = institutionSelectNonUkAddress
+institutionSelectNonUkAddress.error.required = Enter institutionSelectNonUkAddress
+institutionSelectNonUkAddress.error.length = InstitutionSelectNonUkAddress must be 100 characters or less
+institutionSelectNonUkAddress.change.hidden = InstitutionSelectNonUkAddress
+
+institutionSelectUkAddress.title = institutionSelectUkAddress
+institutionSelectUkAddress.heading = institutionSelectUkAddress
+institutionSelectUkAddress.checkYourAnswersLabel = institutionSelectUkAddress
+institutionSelectUkAddress.error.required = Enter institutionSelectUkAddress
+institutionSelectUkAddress.error.length = InstitutionSelectUkAddress must be 100 characters or less
+institutionSelectUkAddress.change.hidden = InstitutionSelectUkAddress
+
+isThisInstitutionAddress.title = isThisInstitutionAddress
+isThisInstitutionAddress.heading = isThisInstitutionAddress
+isThisInstitutionAddress.checkYourAnswersLabel = isThisInstitutionAddress
+isThisInstitutionAddress.error.required = Select yes if isThisInstitutionAddress
+isThisInstitutionAddress.change.hidden = IsThisInstitutionAddress
+
+sendReports.title = sendReports
+sendReports.heading = sendReports
+sendReports.checkYourAnswersLabel = sendReports
+sendReports.error.required = Select yes if sendReports
+sendReports.change.hidden = SendReports
+
+whatIsGIIN.title = whatIsGIIN
+whatIsGIIN.heading = whatIsGIIN
+whatIsGIIN.checkYourAnswersLabel = whatIsGIIN
+whatIsGIIN.error.required = Enter whatIsGIIN
+whatIsGIIN.error.length = WhatIsGIIN must be 100 characters or less
+whatIsGIIN.change.hidden = WhatIsGIIN

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.18.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/controllers/HaveGIINControllerSpec.scala
+++ b/test/controllers/HaveGIINControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class HaveGIINControllerSpec extends SpecBase with MockitoSugar {
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new HaveGIINFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val haveGIINRoute = routes.HaveGIINController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class HaveGIINControllerSpec extends SpecBase with MockitoSugar {
       }
     }
   }
+
 }

--- a/test/controllers/HaveGIINControllerSpec.scala
+++ b/test/controllers/HaveGIINControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.HaveGIINFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.HaveGIINPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.HaveGIINView
+
+import scala.concurrent.Future
+
+class HaveGIINControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new HaveGIINFormProvider()
+  val form = formProvider()
+
+  lazy val haveGIINRoute = routes.HaveGIINController.onPageLoad(NormalMode).url
+
+  "HaveGIIN Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, haveGIINRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[HaveGIINView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(HaveGIINPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, haveGIINRoute)
+
+        val view = application.injector.instanceOf[HaveGIINView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveGIINRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveGIINRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[HaveGIINView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, haveGIINRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveGIINRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/InstitutionLocationControllerSpec.scala
+++ b/test/controllers/InstitutionLocationControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class InstitutionLocationControllerSpec extends SpecBase with MockitoSugar {
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new InstitutionLocationFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val institutionLocationRoute = routes.InstitutionLocationController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class InstitutionLocationControllerSpec extends SpecBase with MockitoSugar {
       }
     }
   }
+
 }

--- a/test/controllers/InstitutionLocationControllerSpec.scala
+++ b/test/controllers/InstitutionLocationControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.InstitutionLocationFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.InstitutionLocationPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.InstitutionLocationView
+
+import scala.concurrent.Future
+
+class InstitutionLocationControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new InstitutionLocationFormProvider()
+  val form = formProvider()
+
+  lazy val institutionLocationRoute = routes.InstitutionLocationController.onPageLoad(NormalMode).url
+
+  "InstitutionLocation Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionLocationRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[InstitutionLocationView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InstitutionLocationPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionLocationRoute)
+
+        val view = application.injector.instanceOf[InstitutionLocationView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionLocationRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionLocationRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[InstitutionLocationView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionLocationRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionLocationRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/InstitutionPostcodeControllerSpec.scala
+++ b/test/controllers/InstitutionPostcodeControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.InstitutionPostcodeFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.InstitutionPostcodePage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.InstitutionPostcodeView
+
+import scala.concurrent.Future
+
+class InstitutionPostcodeControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new InstitutionPostcodeFormProvider()
+  val form = formProvider()
+
+  lazy val institutionPostcodeRoute = routes.InstitutionPostcodeController.onPageLoad(NormalMode).url
+
+  "InstitutionPostcode Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionPostcodeRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[InstitutionPostcodeView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InstitutionPostcodePage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionPostcodeRoute)
+
+        val view = application.injector.instanceOf[InstitutionPostcodeView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionPostcodeRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionPostcodeRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[InstitutionPostcodeView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionPostcodeRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionPostcodeRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/InstitutionPostcodeControllerSpec.scala
+++ b/test/controllers/InstitutionPostcodeControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class InstitutionPostcodeControllerSpec extends SpecBase with MockitoSugar {
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new InstitutionPostcodeFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val institutionPostcodeRoute = routes.InstitutionPostcodeController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class InstitutionPostcodeControllerSpec extends SpecBase with MockitoSugar {
       }
     }
   }
+
 }

--- a/test/controllers/InstitutionSelectAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectAddressControllerSpec.scala
@@ -1,0 +1,142 @@
+package controllers
+
+import base.SpecBase
+import forms.InstitutionSelectAddressFormProvider
+import models.{NormalMode, InstitutionSelectAddress, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.InstitutionSelectAddressPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.InstitutionSelectAddressView
+
+import scala.concurrent.Future
+
+class InstitutionSelectAddressControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  lazy val institutionSelectAddressRoute = routes.InstitutionSelectAddressController.onPageLoad(NormalMode).url
+
+  val formProvider = new InstitutionSelectAddressFormProvider()
+  val form = formProvider()
+
+  "InstitutionSelectAddress Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectAddressRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[InstitutionSelectAddressView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InstitutionSelectAddressPage, InstitutionSelectAddress.values.head).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectAddressRoute)
+
+        val view = application.injector.instanceOf[InstitutionSelectAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(InstitutionSelectAddress.values.head), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectAddressRoute)
+            .withFormUrlEncodedBody(("value", InstitutionSelectAddress.values.head.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectAddressRoute)
+            .withFormUrlEncodedBody(("value", "invalid value"))
+
+        val boundForm = form.bind(Map("value" -> "invalid value"))
+
+        val view = application.injector.instanceOf[InstitutionSelectAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectAddressRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectAddressRoute)
+            .withFormUrlEncodedBody(("value", InstitutionSelectAddress.values.head.toString))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/InstitutionSelectAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectAddressControllerSpec.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
 import forms.InstitutionSelectAddressFormProvider
-import models.{NormalMode, InstitutionSelectAddress, UserAnswers}
+import models.{InstitutionSelectAddress, NormalMode, UserAnswers}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -24,7 +40,7 @@ class InstitutionSelectAddressControllerSpec extends SpecBase with MockitoSugar 
   lazy val institutionSelectAddressRoute = routes.InstitutionSelectAddressController.onPageLoad(NormalMode).url
 
   val formProvider = new InstitutionSelectAddressFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   "InstitutionSelectAddress Controller" - {
 
@@ -139,4 +155,5 @@ class InstitutionSelectAddressControllerSpec extends SpecBase with MockitoSugar 
       }
     }
   }
+
 }

--- a/test/controllers/InstitutionSelectNonUkAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectNonUkAddressControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.InstitutionSelectNonUkAddressFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.InstitutionSelectNonUkAddressPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.InstitutionSelectNonUkAddressView
+
+import scala.concurrent.Future
+
+class InstitutionSelectNonUkAddressControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new InstitutionSelectNonUkAddressFormProvider()
+  val form = formProvider()
+
+  lazy val institutionSelectNonUkAddressRoute = routes.InstitutionSelectNonUkAddressController.onPageLoad(NormalMode).url
+
+  "InstitutionSelectNonUkAddress Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectNonUkAddressRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[InstitutionSelectNonUkAddressView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InstitutionSelectNonUkAddressPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectNonUkAddressRoute)
+
+        val view = application.injector.instanceOf[InstitutionSelectNonUkAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectNonUkAddressRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectNonUkAddressRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[InstitutionSelectNonUkAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectNonUkAddressRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectNonUkAddressRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/InstitutionSelectNonUkAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectNonUkAddressControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class InstitutionSelectNonUkAddressControllerSpec extends SpecBase with MockitoS
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new InstitutionSelectNonUkAddressFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val institutionSelectNonUkAddressRoute = routes.InstitutionSelectNonUkAddressController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class InstitutionSelectNonUkAddressControllerSpec extends SpecBase with MockitoS
       }
     }
   }
+
 }

--- a/test/controllers/InstitutionSelectUkAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectUkAddressControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class InstitutionSelectUkAddressControllerSpec extends SpecBase with MockitoSuga
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new InstitutionSelectUkAddressFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val institutionSelectUkAddressRoute = routes.InstitutionSelectUkAddressController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class InstitutionSelectUkAddressControllerSpec extends SpecBase with MockitoSuga
       }
     }
   }
+
 }

--- a/test/controllers/InstitutionSelectUkAddressControllerSpec.scala
+++ b/test/controllers/InstitutionSelectUkAddressControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.InstitutionSelectUkAddressFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.InstitutionSelectUkAddressPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.InstitutionSelectUkAddressView
+
+import scala.concurrent.Future
+
+class InstitutionSelectUkAddressControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new InstitutionSelectUkAddressFormProvider()
+  val form = formProvider()
+
+  lazy val institutionSelectUkAddressRoute = routes.InstitutionSelectUkAddressController.onPageLoad(NormalMode).url
+
+  "InstitutionSelectUkAddress Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectUkAddressRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[InstitutionSelectUkAddressView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(InstitutionSelectUkAddressPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectUkAddressRoute)
+
+        val view = application.injector.instanceOf[InstitutionSelectUkAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectUkAddressRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectUkAddressRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[InstitutionSelectUkAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, institutionSelectUkAddressRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, institutionSelectUkAddressRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/IsThisInstitutionAddressControllerSpec.scala
+++ b/test/controllers/IsThisInstitutionAddressControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class IsThisInstitutionAddressControllerSpec extends SpecBase with MockitoSugar 
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new IsThisInstitutionAddressFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val isThisInstitutionAddressRoute = routes.IsThisInstitutionAddressController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class IsThisInstitutionAddressControllerSpec extends SpecBase with MockitoSugar 
       }
     }
   }
+
 }

--- a/test/controllers/IsThisInstitutionAddressControllerSpec.scala
+++ b/test/controllers/IsThisInstitutionAddressControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.IsThisInstitutionAddressFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.IsThisInstitutionAddressPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.IsThisInstitutionAddressView
+
+import scala.concurrent.Future
+
+class IsThisInstitutionAddressControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new IsThisInstitutionAddressFormProvider()
+  val form = formProvider()
+
+  lazy val isThisInstitutionAddressRoute = routes.IsThisInstitutionAddressController.onPageLoad(NormalMode).url
+
+  "IsThisInstitutionAddress Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, isThisInstitutionAddressRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[IsThisInstitutionAddressView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(IsThisInstitutionAddressPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, isThisInstitutionAddressRoute)
+
+        val view = application.injector.instanceOf[IsThisInstitutionAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, isThisInstitutionAddressRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, isThisInstitutionAddressRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[IsThisInstitutionAddressView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, isThisInstitutionAddressRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, isThisInstitutionAddressRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/SendReportsControllerSpec.scala
+++ b/test/controllers/SendReportsControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class SendReportsControllerSpec extends SpecBase with MockitoSugar {
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new SendReportsFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val sendReportsRoute = routes.SendReportsController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class SendReportsControllerSpec extends SpecBase with MockitoSugar {
       }
     }
   }
+
 }

--- a/test/controllers/SendReportsControllerSpec.scala
+++ b/test/controllers/SendReportsControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.SendReportsFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.SendReportsPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.SendReportsView
+
+import scala.concurrent.Future
+
+class SendReportsControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new SendReportsFormProvider()
+  val form = formProvider()
+
+  lazy val sendReportsRoute = routes.SendReportsController.onPageLoad(NormalMode).url
+
+  "SendReports Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, sendReportsRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[SendReportsView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(SendReportsPage, true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, sendReportsRoute)
+
+        val view = application.injector.instanceOf[SendReportsView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, sendReportsRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, sendReportsRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[SendReportsView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, sendReportsRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, sendReportsRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/controllers/WhatIsGIINControllerSpec.scala
+++ b/test/controllers/WhatIsGIINControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -22,7 +38,7 @@ class WhatIsGIINControllerSpec extends SpecBase with MockitoSugar {
   def onwardRoute = Call("GET", "/foo")
 
   val formProvider = new WhatIsGIINFormProvider()
-  val form = formProvider()
+  val form         = formProvider()
 
   lazy val whatIsGIINRoute = routes.WhatIsGIINController.onPageLoad(NormalMode).url
 
@@ -138,4 +154,5 @@ class WhatIsGIINControllerSpec extends SpecBase with MockitoSugar {
       }
     }
   }
+
 }

--- a/test/controllers/WhatIsGIINControllerSpec.scala
+++ b/test/controllers/WhatIsGIINControllerSpec.scala
@@ -1,0 +1,141 @@
+package controllers
+
+import base.SpecBase
+import forms.WhatIsGIINFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.WhatIsGIINPage
+import play.api.inject.bind
+import play.api.mvc.Call
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.SessionRepository
+import views.html.WhatIsGIINView
+
+import scala.concurrent.Future
+
+class WhatIsGIINControllerSpec extends SpecBase with MockitoSugar {
+
+  def onwardRoute = Call("GET", "/foo")
+
+  val formProvider = new WhatIsGIINFormProvider()
+  val form = formProvider()
+
+  lazy val whatIsGIINRoute = routes.WhatIsGIINController.onPageLoad(NormalMode).url
+
+  "WhatIsGIIN Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, whatIsGIINRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[WhatIsGIINView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId).set(WhatIsGIINPage, "answer").success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, whatIsGIINRoute)
+
+        val view = application.injector.instanceOf[WhatIsGIINView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      val mockSessionRepository = mock[SessionRepository]
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
+            bind[SessionRepository].toInstance(mockSessionRepository)
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, whatIsGIINRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, whatIsGIINRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[WhatIsGIINView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, whatIsGIINRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, whatIsGIINRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/forms/HaveGIINFormProviderSpec.scala
+++ b/test/forms/HaveGIINFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
@@ -6,7 +22,7 @@ import play.api.data.FormError
 class HaveGIINFormProviderSpec extends BooleanFieldBehaviours {
 
   val requiredKey = "haveGIIN.error.required"
-  val invalidKey = "error.boolean"
+  val invalidKey  = "error.boolean"
 
   val form = new HaveGIINFormProvider()()
 
@@ -26,4 +42,5 @@ class HaveGIINFormProviderSpec extends BooleanFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/HaveGIINFormProviderSpec.scala
+++ b/test/forms/HaveGIINFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class HaveGIINFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "haveGIIN.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new HaveGIINFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InstitutionLocationFormProviderSpec.scala
+++ b/test/forms/InstitutionLocationFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class InstitutionLocationFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "institutionLocation.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new InstitutionLocationFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InstitutionLocationFormProviderSpec.scala
+++ b/test/forms/InstitutionLocationFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
@@ -6,7 +22,7 @@ import play.api.data.FormError
 class InstitutionLocationFormProviderSpec extends BooleanFieldBehaviours {
 
   val requiredKey = "institutionLocation.error.required"
-  val invalidKey = "error.boolean"
+  val invalidKey  = "error.boolean"
 
   val form = new InstitutionLocationFormProvider()()
 
@@ -26,4 +42,5 @@ class InstitutionLocationFormProviderSpec extends BooleanFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/InstitutionPostcodeFormProviderSpec.scala
+++ b/test/forms/InstitutionPostcodeFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class InstitutionPostcodeFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "institutionPostcode.error.required"
+  val lengthKey = "institutionPostcode.error.length"
+  val maxLength = 10
+
+  val form = new InstitutionPostcodeFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InstitutionPostcodeFormProviderSpec.scala
+++ b/test/forms/InstitutionPostcodeFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours
@@ -6,8 +22,8 @@ import play.api.data.FormError
 class InstitutionPostcodeFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "institutionPostcode.error.required"
-  val lengthKey = "institutionPostcode.error.length"
-  val maxLength = 10
+  val lengthKey   = "institutionPostcode.error.length"
+  val maxLength   = 10
 
   val form = new InstitutionPostcodeFormProvider()()
 
@@ -34,4 +50,5 @@ class InstitutionPostcodeFormProviderSpec extends StringFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/InstitutionSelectAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectAddressFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.OptionFieldBehaviours
@@ -10,13 +26,13 @@ class InstitutionSelectAddressFormProviderSpec extends OptionFieldBehaviours {
 
   ".value" - {
 
-    val fieldName = "value"
+    val fieldName   = "value"
     val requiredKey = "institutionSelectAddress.error.required"
 
     behave like optionsField[InstitutionSelectAddress](
       form,
       fieldName,
-      validValues  = InstitutionSelectAddress.values,
+      validValues = InstitutionSelectAddress.values,
       invalidError = FormError(fieldName, "error.invalid")
     )
 
@@ -26,4 +42,5 @@ class InstitutionSelectAddressFormProviderSpec extends OptionFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/InstitutionSelectAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectAddressFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.OptionFieldBehaviours
+import models.InstitutionSelectAddress
+import play.api.data.FormError
+
+class InstitutionSelectAddressFormProviderSpec extends OptionFieldBehaviours {
+
+  val form = new InstitutionSelectAddressFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+    val requiredKey = "institutionSelectAddress.error.required"
+
+    behave like optionsField[InstitutionSelectAddress](
+      form,
+      fieldName,
+      validValues  = InstitutionSelectAddress.values,
+      invalidError = FormError(fieldName, "error.invalid")
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InstitutionSelectNonUkAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectNonUkAddressFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class InstitutionSelectNonUkAddressFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "institutionSelectNonUkAddress.error.required"
+  val lengthKey = "institutionSelectNonUkAddress.error.length"
+  val maxLength = 100
+
+  val form = new InstitutionSelectNonUkAddressFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/InstitutionSelectNonUkAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectNonUkAddressFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours
@@ -6,8 +22,8 @@ import play.api.data.FormError
 class InstitutionSelectNonUkAddressFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "institutionSelectNonUkAddress.error.required"
-  val lengthKey = "institutionSelectNonUkAddress.error.length"
-  val maxLength = 100
+  val lengthKey   = "institutionSelectNonUkAddress.error.length"
+  val maxLength   = 100
 
   val form = new InstitutionSelectNonUkAddressFormProvider()()
 
@@ -34,4 +50,5 @@ class InstitutionSelectNonUkAddressFormProviderSpec extends StringFieldBehaviour
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/InstitutionSelectUkAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectUkAddressFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours
@@ -6,8 +22,8 @@ import play.api.data.FormError
 class InstitutionSelectUkAddressFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "institutionSelectUkAddress.error.required"
-  val lengthKey = "institutionSelectUkAddress.error.length"
-  val maxLength = 100
+  val lengthKey   = "institutionSelectUkAddress.error.length"
+  val maxLength   = 100
 
   val form = new InstitutionSelectUkAddressFormProvider()()
 
@@ -34,4 +50,5 @@ class InstitutionSelectUkAddressFormProviderSpec extends StringFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/InstitutionSelectUkAddressFormProviderSpec.scala
+++ b/test/forms/InstitutionSelectUkAddressFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class InstitutionSelectUkAddressFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "institutionSelectUkAddress.error.required"
+  val lengthKey = "institutionSelectUkAddress.error.length"
+  val maxLength = 100
+
+  val form = new InstitutionSelectUkAddressFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/IsThisInstitutionAddressFormProviderSpec.scala
+++ b/test/forms/IsThisInstitutionAddressFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class IsThisInstitutionAddressFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "isThisInstitutionAddress.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new IsThisInstitutionAddressFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/IsThisInstitutionAddressFormProviderSpec.scala
+++ b/test/forms/IsThisInstitutionAddressFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
@@ -6,7 +22,7 @@ import play.api.data.FormError
 class IsThisInstitutionAddressFormProviderSpec extends BooleanFieldBehaviours {
 
   val requiredKey = "isThisInstitutionAddress.error.required"
-  val invalidKey = "error.boolean"
+  val invalidKey  = "error.boolean"
 
   val form = new IsThisInstitutionAddressFormProvider()()
 
@@ -26,4 +42,5 @@ class IsThisInstitutionAddressFormProviderSpec extends BooleanFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/SendReportsFormProviderSpec.scala
+++ b/test/forms/SendReportsFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.BooleanFieldBehaviours
@@ -6,7 +22,7 @@ import play.api.data.FormError
 class SendReportsFormProviderSpec extends BooleanFieldBehaviours {
 
   val requiredKey = "sendReports.error.required"
-  val invalidKey = "error.boolean"
+  val invalidKey  = "error.boolean"
 
   val form = new SendReportsFormProvider()()
 
@@ -26,4 +42,5 @@ class SendReportsFormProviderSpec extends BooleanFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/SendReportsFormProviderSpec.scala
+++ b/test/forms/SendReportsFormProviderSpec.scala
@@ -1,0 +1,29 @@
+package forms
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class SendReportsFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "sendReports.error.required"
+  val invalidKey = "error.boolean"
+
+  val form = new SendReportsFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/forms/WhatIsGIINFormProviderSpec.scala
+++ b/test/forms/WhatIsGIINFormProviderSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package forms
 
 import forms.behaviours.StringFieldBehaviours
@@ -6,8 +22,8 @@ import play.api.data.FormError
 class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
 
   val requiredKey = "whatIsGIIN.error.required"
-  val lengthKey = "whatIsGIIN.error.length"
-  val maxLength = 100
+  val lengthKey   = "whatIsGIIN.error.length"
+  val maxLength   = 100
 
   val form = new WhatIsGIINFormProvider()()
 
@@ -34,4 +50,5 @@ class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
       requiredError = FormError(fieldName, requiredKey)
     )
   }
+
 }

--- a/test/forms/WhatIsGIINFormProviderSpec.scala
+++ b/test/forms/WhatIsGIINFormProviderSpec.scala
@@ -1,0 +1,37 @@
+package forms
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "whatIsGIIN.error.required"
+  val lengthKey = "whatIsGIIN.error.length"
+  val maxLength = 100
+
+  val form = new WhatIsGIINFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+}

--- a/test/models/InstitutionSelectAddressSpec.scala
+++ b/test/models/InstitutionSelectAddressSpec.scala
@@ -1,0 +1,48 @@
+package models
+
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.OptionValues
+import play.api.libs.json.{JsError, JsString, Json}
+
+class InstitutionSelectAddressSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with OptionValues {
+
+  "InstitutionSelectAddress" - {
+
+    "must deserialise valid values" in {
+
+      val gen = Gen.oneOf(InstitutionSelectAddress.values.toSeq)
+
+      forAll(gen) {
+        institutionSelectAddress =>
+
+          JsString(institutionSelectAddress.toString).validate[InstitutionSelectAddress].asOpt.value mustEqual institutionSelectAddress
+      }
+    }
+
+    "must fail to deserialise invalid values" in {
+
+      val gen = arbitrary[String] suchThat (!InstitutionSelectAddress.values.map(_.toString).contains(_))
+
+      forAll(gen) {
+        invalidValue =>
+
+          JsString(invalidValue).validate[InstitutionSelectAddress] mustEqual JsError("error.invalid")
+      }
+    }
+
+    "must serialise" in {
+
+      val gen = Gen.oneOf(InstitutionSelectAddress.values.toSeq)
+
+      forAll(gen) {
+        institutionSelectAddress =>
+
+          Json.toJson(institutionSelectAddress) mustEqual JsString(institutionSelectAddress.toString)
+      }
+    }
+  }
+}

--- a/test/models/InstitutionSelectAddressSpec.scala
+++ b/test/models/InstitutionSelectAddressSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package models
 
 import org.scalacheck.Arbitrary.arbitrary
@@ -18,7 +34,6 @@ class InstitutionSelectAddressSpec extends AnyFreeSpec with Matchers with ScalaC
 
       forAll(gen) {
         institutionSelectAddress =>
-
           JsString(institutionSelectAddress.toString).validate[InstitutionSelectAddress].asOpt.value mustEqual institutionSelectAddress
       }
     }
@@ -29,7 +44,6 @@ class InstitutionSelectAddressSpec extends AnyFreeSpec with Matchers with ScalaC
 
       forAll(gen) {
         invalidValue =>
-
           JsString(invalidValue).validate[InstitutionSelectAddress] mustEqual JsError("error.invalid")
       }
     }
@@ -40,9 +54,9 @@ class InstitutionSelectAddressSpec extends AnyFreeSpec with Matchers with ScalaC
 
       forAll(gen) {
         institutionSelectAddress =>
-
           Json.toJson(institutionSelectAddress) mustEqual JsString(institutionSelectAddress.toString)
       }
     }
   }
+
 }


### PR DESCRIPTION
DAC6-2806 | /where-is-fi-based | Yes/no | InstitutionLocation
-- | -- | -- | --
DAC6-2807 | /uk-postcode | string? Postcode finder | InstitutionPostcode
DAC6-2808 | /select-address | Radio? address select | InstitutionSelectAddress
DAC6-2809 | /is-this-the-address | yes/no | IsThisInstitutionAddress
DAC6-2810 | /address-uk | String (7 fields) | InstitutionSelectUkAddress
DAC6-2811 | /address-non-uk | String (7 fields) (why different) | InstitutionSelectNonUkAddress
DAC6-2986 | /fatca-reports | Yes/no | SendReports
DAC6-2987 | /have-giin | Yes/no | HaveGIIN
DAC6-2743 | /giin | String | WhatIsGIIN



also updated sbt-auto-build to v3.18.0
