### PR TITLE
DAC6-2738: Add SecondContactCanWePhonePage

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -30,6 +30,18 @@ class Navigator @Inject() () {
 
     case ContactNamePage =>
       _ => routes.FirstContactEmailController.onPageLoad(NormalMode)
+    case NameOfFinancialInstitutionPage =>
+      _ => routes.HaveUniqueTaxpayerReferenceController.onPageLoad(NormalMode)
+    case SecondContactNamePage =>
+      _ => routes.SecondContactEmailController.onPageLoad(NormalMode)
+    case SecondContactCanWePhonePage =>
+      userAnswers =>
+        yesNoPage(
+          userAnswers,
+          SecondContactCanWePhonePage,
+          routes.SecondContactPhoneNumberController.onPageLoad(NormalMode),
+          routes.CheckYourAnswersController.onPageLoad
+        )
     case SecondContactPhoneNumberPage => _ => routes.CheckYourAnswersController.onPageLoad
     case _ =>
       _ => routes.IndexController.onPageLoad
@@ -39,6 +51,11 @@ class Navigator @Inject() () {
     case _ =>
       _ => routes.CheckYourAnswersController.onPageLoad
   }
+
+  private def yesNoPage(ua: UserAnswers, fromPage: QuestionPage[Boolean], yesCall: => Call, noCall: => Call): Call =
+    ua.get(fromPage)
+      .map(if (_) yesCall else noCall)
+      .getOrElse(controllers.routes.JourneyRecoveryController.onPageLoad())
 
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call = mode match {
     case NormalMode =>

--- a/app/utils/ContactHelper.scala
+++ b/app/utils/ContactHelper.scala
@@ -17,7 +17,7 @@
 package utils
 
 import models.UserAnswers
-import pages.ContactNamePage
+import pages.{ContactNamePage, SecondContactNamePage}
 import play.api.i18n.Messages
 
 trait ContactHelper {
@@ -26,6 +26,13 @@ trait ContactHelper {
     userAnswers
       .get(ContactNamePage)
       .fold(messages("default.firstContact.name"))(
+        contactName => contactName
+      )
+
+  def getSecondContactName(userAnswers: UserAnswers)(implicit messages: Messages): String =
+    userAnswers
+      .get(SecondContactNamePage)
+      .fold(messages("default.secondContact.name"))(
         contactName => contactName
       )
 

--- a/app/views/SecondContactCanWePhoneView.scala.html
+++ b/app/views/SecondContactCanWePhoneView.scala.html
@@ -14,15 +14,19 @@
  * limitations under the License.
  *@
 
+@import components._
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    govukButton: GovukButton
+    govukButton: GovukButton,
+    heading: Heading,
+    paragraph: Paragraph
 )
 
-@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, financialInstitutionName: String, secondContactName: String)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("secondContactCanWePhone.title"))) {
 
@@ -32,15 +36,18 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
+        @heading(messages("secondContactCanWePhone.heading", secondContactName))
+        @paragraph(Html(messages("secondContactCanWePhone.p1", financialInstitutionName)))
+
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("secondContactCanWePhone.heading")).asPageHeading()
+                legend = LegendViewModel(messages("secondContactCanWePhone.heading", secondContactName)).withCssClass("govuk-visually-hidden")
             )
         )
 
         @govukButton(
-            ButtonViewModel(messages("site.continue"))
+            ButtonViewModel(messages("site.continue")).withAttribute("id" -> "submit")
         )
     }
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -55,10 +55,10 @@ POST        /second-contact-email                        controllers.SecondConta
 GET         /change-second-contact-email                 controllers.SecondContactEmailController.onPageLoad(mode: Mode = CheckMode)
 POST        /change-second-contact-email                 controllers.SecondContactEmailController.onSubmit(mode: Mode = CheckMode)
 
-GET         /secondContactCanWePhone                     controllers.SecondContactCanWePhoneController.onPageLoad(mode: Mode = NormalMode)
-POST        /secondContactCanWePhone                     controllers.SecondContactCanWePhoneController.onSubmit(mode: Mode = NormalMode)
-GET         /changeSecondContactCanWePhone               controllers.SecondContactCanWePhoneController.onPageLoad(mode: Mode = CheckMode)
-POST        /changeSecondContactCanWePhone               controllers.SecondContactCanWePhoneController.onSubmit(mode: Mode = CheckMode)
+GET         /second-contact-have-phone                   controllers.SecondContactCanWePhoneController.onPageLoad(mode: Mode = NormalMode)
+POST        /second-contact-have-phone                   controllers.SecondContactCanWePhoneController.onSubmit(mode: Mode = NormalMode)
+GET         /change-second-contact-have-phone            controllers.SecondContactCanWePhoneController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-second-contact-have-phone            controllers.SecondContactCanWePhoneController.onSubmit(mode: Mode = CheckMode)
 
 GET         /second-contact-phone                        controllers.SecondContactPhoneNumberController.onPageLoad(mode: Mode = NormalMode)
 POST        /second-contact-phone                        controllers.SecondContactPhoneNumberController.onSubmit(mode: Mode = NormalMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -43,6 +43,9 @@ index.guidance = Welcome to your new frontend. Please see the README file for a 
 checkYourAnswers.title = Check Your Answers
 checkYourAnswers.heading = Check Your Answers
 
+default.firstContact.name = your first contact
+default.secondContact.name = your second contact
+
 journeyRecovery.continue.title = Sorry, there is a problem with the service
 journeyRecovery.continue.heading = Sorry, there is a problem with the service
 journeyRecovery.continue.guidance = [Add content to explain how to proceed.]
@@ -72,8 +75,6 @@ firstContactEmail.error.length = The email address must be 132 characters or les
 firstContactEmail.error.format = Enter an email address in the right format, like yourname@example.com
 firstContactEmail.change.hidden = Change email for financial institution contact
 
-default.firstContact.name = your first contact
-
 firstContactPhoneNumber.checkYourAnswersLabel = First contact telephone number
 firstContactPhoneNumber.title = What is the telephone number for the first contact?
 firstContactPhoneNumber.heading = What is the telephone number for {0}?
@@ -83,11 +84,12 @@ firstContactPhoneNumber.error.invalid = The telephone number must only include n
 firstContactPhoneNumber.error.length = The telephone number must be 24 characters or less
 firstContactPhoneNumber.change.hidden = Change first contact telephone number
 
-secondContactCanWePhone.title = secondContactCanWePhone
-secondContactCanWePhone.heading = secondContactCanWePhone
-secondContactCanWePhone.checkYourAnswersLabel = secondContactCanWePhone
-secondContactCanWePhone.error.required = Select yes if secondContactCanWePhone
-secondContactCanWePhone.change.hidden = SecondContactCanWePhone
+secondContactCanWePhone.title = Can we contact the second contact by telephone?
+secondContactCanWePhone.heading = Can we contact {0} by telephone?
+secondContactCanWePhone.p1 = We will call if we have any questions about reports for {0}.
+secondContactCanWePhone.checkYourAnswersLabel = Can we contact {0} by telephone?
+secondContactCanWePhone.error.required = Select yes if they can be contacted by telephone
+secondContactCanWePhone.change.hidden = Change can we contact {0} by telephone?
 
 secondContactEmail.title = secondContactEmail
 secondContactEmail.heading = secondContactEmail

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -26,7 +26,9 @@ import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.Writes
 import play.api.test.FakeRequest
+import queries.Settable
 
 trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValues with ScalaFutures with IntegrationPatience {
 
@@ -43,5 +45,12 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         bind[IdentifierAction].to[FakeIdentifierAction],
         bind[DataRetrievalAction].toInstance(new FakeDataRetrievalAction(userAnswers))
       )
+
+  implicit class UserAnswersExtension(userAnswers: UserAnswers) {
+
+    def withPage[T](page: Settable[T], value: T)(implicit writes: Writes[T]): UserAnswers =
+      userAnswers.set(page, value).success.value
+
+  }
 
 }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -43,6 +43,18 @@ class NavigatorSpec extends SpecBase {
           routes.CheckYourAnswersController.onPageLoad
       }
 
+      "must go from SecondContactCanWePhonePage to SecondContactPhoneNumberPage when user answers yes" in {
+        val userAnswers = emptyUserAnswers.withPage(SecondContactCanWePhonePage, true)
+        navigator.nextPage(SecondContactCanWePhonePage, NormalMode, userAnswers) mustBe
+          routes.SecondContactPhoneNumberController.onPageLoad(NormalMode)
+      }
+
+      "must go from SecondContactCanWePhonePage to CheckYourAnswersPage when user answers no" in {
+        val userAnswers = emptyUserAnswers.withPage(SecondContactCanWePhonePage, false)
+        navigator.nextPage(SecondContactCanWePhonePage, NormalMode, userAnswers) mustBe
+          routes.CheckYourAnswersController.onPageLoad
+      }
+
     }
 
     "in Check mode" - {


### PR DESCRIPTION
To test this visit:
- /
- /nameOfFinancialInstitution
- /second-contact-name
- and then /second-contact-have-phone 

<img width="998" alt="Screenshot 2024-01-17 at 13 51 46" src="https://github.com/hmrc/crs-fatca-fi-management-frontend/assets/8526655/333453f2-d081-487c-a7da-259a89fab7f1">

