### PR TITLE
DAC6-3131: Updated feedback-frontend config

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -29,10 +29,9 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   val appName: String = configuration.get[String]("appName")
 
   private val contactHost                  = configuration.get[String]("contact-frontend.host")
-  private val contactFormServiceIdentifier = "crs-fatca-fi-management-frontend"
 
   def feedbackUrl(implicit request: RequestHeader): String =
-    s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"
+    s"$contactHost/contact/beta-feedback?service=$appName&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"
 
   val loginUrl: String              = configuration.get[String]("urls.login")
   val loginContinueUrl: String      = configuration.get[String]("urls.loginContinue")
@@ -40,8 +39,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   lazy val lostUTRUrl: String       = configuration.get[String]("urls.lostUTR")
   lazy val addressLookUpUrl: String = configuration.get[Service]("microservice.services.address-lookup").baseUrl
 
-  private val exitSurveyBaseUrl: String = configuration.get[Service]("microservice.services.feedback-frontend").baseUrl
-  val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/crs-fatca-fi-management-frontend"
+  private val exitSurveyBaseUrl: String = configuration.get[String]("feedback-frontend.host")
+  val exitSurveyUrl: String             = s"$exitSurveyBaseUrl/feedback/$appName"
 
   val languageTranslationEnabled: Boolean =
     configuration.get[Boolean]("features.welsh-translation")

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -28,7 +28,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   val host: String    = configuration.get[String]("host")
   val appName: String = configuration.get[String]("appName")
 
-  private val contactHost                  = configuration.get[String]("contact-frontend.host")
+  private val contactHost = configuration.get[String]("contact-frontend.host")
 
   def feedbackUrl(implicit request: RequestHeader): String =
     s"$contactHost/contact/beta-feedback?service=$appName&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -71,12 +71,12 @@ mongodb {
 
 urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
-  loginContinue = "http://localhost:9000/crs-fatca-fi-management-frontend"
+  loginContinue = "http://localhost:10033/manage-your-crs-and-fatca-financial-institutions"
   signOut       = "http://localhost:9025/gg/sign-out"
   lostUTR       = "https://www.gov.uk/find-lost-utr-number"
 }
 
-host = "http://localhost:9000"
+host = "http://localhost:10033"
 
 accessibility-statement{
   service-path = "/crs-fatca-fi-management-frontend"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,20 +34,14 @@ microservice {
     services {
       auth {
         protocol = http
-        host     = localhost
-        port     = 8500
+        host = localhost
+        port = 8500
       }
 
       address-lookup {
+        protocol = http
         host = localhost
         port = 9022
-        protocol = http
-      }
-
-      feedback-frontend {
-        protocol = http
-        host     = localhost
-        port     = 9514
       }
     }
 }
@@ -55,6 +49,10 @@ microservice {
 contact-frontend {
   host      = "http://localhost:9250"
   serviceId = "crs-fatca-fi-management-frontend"
+}
+
+feedback-frontend {
+  host = "http://localhost:9514"
 }
 
 timeout-dialog {


### PR DESCRIPTION
Simplified the feedback-frontend config and made it match the contact-frontend config.

Using `baseUrl` meant we had to provide a protocol/host/port combination which is unnecessarily complex for a simple frontend redirect url.

Also spotted and fixed - some of the localhost config was still set at port 9000 rather than the correct 10033 for this service. Updated them.