### PR TITLE
Updated routing for FI name page if FI=User

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -31,7 +31,12 @@ class Navigator @Inject() () {
   private val normalRoutes: Page => UserAnswers => Call = {
 
     case NameOfFinancialInstitutionPage =>
-      _ => routes.HaveUniqueTaxpayerReferenceController.onPageLoad(NormalMode)
+      userAnswers =>
+        isFiUser(
+          userAnswers,
+          routes.SendReportsController.onPageLoad(NormalMode),
+          routes.HaveUniqueTaxpayerReferenceController.onPageLoad(NormalMode)
+        )
     case WhatIsUniqueTaxpayerReferencePage =>
       _ => routes.SendReportsController.onPageLoad(NormalMode)
     case SendReportsPage =>

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -110,7 +110,13 @@ class NavigatorSpec extends SpecBase {
           routes.CheckYourAnswersController.onPageLoad
       }
 
-      "must go from NameOfFinancialInstitutionPage to HaveUniqueTaxpayerReferencePage" in {
+      "must go from NameOfFinancialInstitutionPage to SendReportsPage when user is FI" in {
+        val userAnswers = emptyUserAnswers.withPage(ReportForRegisteredBusinessPage, true)
+        navigator.nextPage(NameOfFinancialInstitutionPage, NormalMode, userAnswers) mustBe
+          routes.SendReportsController.onPageLoad(NormalMode)
+      }
+
+      "must go from NameOfFinancialInstitutionPage to HaveUniqueTaxpayerReferencePage when user is not FI" in {
         val userAnswers = emptyUserAnswers.withPage(NameOfFinancialInstitutionPage, "FI")
         navigator.nextPage(NameOfFinancialInstitutionPage, NormalMode, userAnswers) mustBe
           routes.HaveUniqueTaxpayerReferenceController.onPageLoad(NormalMode)


### PR DESCRIPTION
Added in the "Is this FI also the user" check after the FI name page:

![image](https://github.com/hmrc/crs-fatca-fi-management-frontend/assets/238270/5df5de2c-4b40-4c61-b07e-b93d54dc3d70)

If FI = User navigation is from /name to /have-utr
If FI != User navigation is from /name to /fatca-reports