### PR TITLE
DAC6-3244: Refactored how we add an FI

### DIFF
--- a/app/controllers/IndexController.scala
+++ b/app/controllers/IndexController.scala
@@ -36,26 +36,19 @@ class IndexController @Inject() (
   identify: IdentifierAction,
   subscriptionService: SubscriptionService,
   conf: FrontendAppConfig,
-  retrieveCtUTR: CtUtrRetrievalAction,
   view: IndexView
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with Logging
     with I18nSupport {
 
-  private lazy val addFIUrl =
-    controllers.addFinancialInstitution.routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode).url
-
-  private lazy val addUserAsFIUrl =
-    controllers.addFinancialInstitution.registeredBusiness.routes.ReportForRegisteredBusinessController.onPageLoad(NormalMode).url
-
-  def onPageLoad(): Action[AnyContent] = (identify andThen retrieveCtUTR()).async {
+  def onPageLoad(): Action[AnyContent] = identify.async {
     implicit request =>
       val fatcaId = request.fatcaId
       subscriptionService.getSubscription(fatcaId).flatMap {
         sub =>
           val changeContactDetailsUrl = if (sub.isBusiness) conf.changeOrganisationDetailsUrl else conf.changeIndividualDetailsUrl
-          val addNewFIUrl             = if (request.autoMatched) addUserAsFIUrl else addFIUrl
+          val addNewFIUrl             = controllers.addFinancialInstitution.routes.AddFIController.onPageLoad.url
 
           sessionRepository.get(request.userId) flatMap {
             case Some(_) => Future.successful(Ok(view(sub.isBusiness, sub.businessName, fatcaId, addNewFIUrl, changeContactDetailsUrl)))

--- a/app/controllers/addFinancialInstitution/AddFIController.scala
+++ b/app/controllers/addFinancialInstitution/AddFIController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.addFinancialInstitution
+
+import controllers.actions.{CtUtrRetrievalAction, IdentifierAction}
+import models.NormalMode
+
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+
+import scala.concurrent.Future
+
+class AddFIController @Inject() (
+  val controllerComponents: MessagesControllerComponents,
+  identify: IdentifierAction,
+  retrieveCtUTR: CtUtrRetrievalAction
+) extends FrontendBaseController {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen retrieveCtUTR()).async {
+    implicit request =>
+      val redirectUrl = if (request.autoMatched) {
+        controllers.addFinancialInstitution.registeredBusiness.routes.ReportForRegisteredBusinessController.onPageLoad(NormalMode)
+      } else {
+        routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
+      }
+
+      Future.successful(Redirect(redirectUrl))
+  }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -19,6 +19,8 @@ GET         /account/signed-out                          controllers.auth.Signed
 
 GET         /unauthorised                                controllers.UnauthorisedController.onPageLoad
 
+GET         /add                                         controllers.addFinancialInstitution.AddFIController.onPageLoad
+
 GET         /contact-name                                controllers.addFinancialInstitution.FirstContactNameController.onPageLoad(mode: Mode = NormalMode)
 POST        /contact-name                                controllers.addFinancialInstitution.FirstContactNameController.onSubmit(mode: Mode = NormalMode)
 GET         /change/contact-name                         controllers.addFinancialInstitution.FirstContactNameController.onPageLoad(mode: Mode = CheckMode)

--- a/test/controllers/actions/FakeCtUtrRetrievalAction.scala
+++ b/test/controllers/actions/FakeCtUtrRetrievalAction.scala
@@ -16,24 +16,19 @@
 
 package controllers.actions
 
-import models.UniqueTaxpayerReference
 import models.requests.IdentifierRequest
 import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeCtUtrRetrievalActionProvider(
-  utr: Option[UniqueTaxpayerReference] = None
-) extends CtUtrRetrievalAction {
+class FakeCtUtrRetrievalActionProvider extends CtUtrRetrievalAction {
 
   def apply(): ActionFunction[IdentifierRequest, IdentifierRequest] =
-    new FakeCtUtrRetrievalAction(utr)
+    new FakeCtUtrRetrievalAction()
 
 }
 
-class FakeCtUtrRetrievalAction(
-  utr: Option[UniqueTaxpayerReference] = None
-) extends ActionFunction[IdentifierRequest, IdentifierRequest] {
+class FakeCtUtrRetrievalAction extends ActionFunction[IdentifierRequest, IdentifierRequest] {
 
   override def invokeBlock[A](request: IdentifierRequest[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
     block(request.copy(autoMatched = true))

--- a/test/controllers/addFinancialInstitution/AddFIControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/AddFIControllerSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.addFinancialInstitution
+
+import base.SpecBase
+import controllers.actions.{CtUtrRetrievalAction, FakeCtUtrRetrievalAction}
+import models.NormalMode
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class AddFIControllerSpec extends SpecBase {
+
+  "Add FI Controller" - {
+
+    "if has CT UTR" - {
+      "must redirect to name of report for registered business page" in {
+        val mockCtUtrRetrievalAction: CtUtrRetrievalAction = mock[CtUtrRetrievalAction]
+        when(mockCtUtrRetrievalAction.apply()).thenReturn(new FakeCtUtrRetrievalAction())
+
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[CtUtrRetrievalAction].toInstance(mockCtUtrRetrievalAction)
+          )
+          .build()
+
+        running(application) {
+          val request = FakeRequest(GET, routes.AddFIController.onPageLoad.url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustBe Some(
+            controllers.addFinancialInstitution.registeredBusiness.routes.ReportForRegisteredBusinessController.onPageLoad(NormalMode).url
+          )
+        }
+      }
+    }
+
+    "if does not have CT UTR" - {
+      "must redirect to name of financial institution page" in {
+        val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+        running(application) {
+          val request = FakeRequest(GET, routes.AddFIController.onPageLoad.url)
+
+          val result = route(application, request).value
+
+          status(result) mustEqual SEE_OTHER
+          redirectLocation(result) mustBe Some(routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode).url)
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
We now have one single URL for adding an FI - `/add` - it will do all of the logic of checking for a CT enrolment and/or checking the number of FIs the user has, before redirecting the user to the correct page (/name or /report-as-registered-business).

This means anywhere that we have a link to add an FI we can just use this single url and we do not need to worry about the any of the logic of deciding which route to take them on.