### PR TITLE
DAC6-3231: Retrieving the address from Registration for /is-the-address-correct

### DIFF
--- a/app/connectors/RegistrationWithUtrConnector.scala
+++ b/app/connectors/RegistrationWithUtrConnector.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.FrontendAppConfig
-import models.RegistrationInfo
+import models.UniqueTaxpayerReference
 import play.api.Logging
 import uk.gov.hmrc.http._
 
@@ -28,13 +28,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class RegistrationWithUtrConnector @Inject() (val config: FrontendAppConfig, val http: HttpClient) extends Logging {
 
   def sendAndRetrieveRegWithUtr(
-    uniqueTaxpayerReference: String
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegistrationInfo] = {
+    uniqueTaxpayerReference: UniqueTaxpayerReference
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
 
-    val endpoint = new URL(s"${config.registrationUrl}/crs-fatca-registration/registration/v2/organisation/utr")
+    val endpoint = new URL(s"${config.registrationUrl}/crs-fatca-registration/registration/organisation/utr-only")
 
-    http.POST[String, RegistrationInfo](endpoint, uniqueTaxpayerReference)
-
+    http.POST[UniqueTaxpayerReference, HttpResponse](endpoint, uniqueTaxpayerReference)
   }
 
 }

--- a/app/connectors/RegistrationWithUtrConnector.scala
+++ b/app/connectors/RegistrationWithUtrConnector.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.FrontendAppConfig
+import play.api.Logging
+import uk.gov.hmrc.http._
+
+import java.net.URL
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class RegistrationWithUtrConnector @Inject() (val config: FrontendAppConfig, val http: HttpClient) extends Logging {
+
+  def sendAndRetrieveRegWithUtr(
+    uniqueTaxpayerReference: String
+  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
+
+    val endpoint = new URL(s"${config.registrationUrl}/crs-fatca-registration/registration/v2/organisation/utr")
+
+    http.POST[String, HttpResponse](endpoint, uniqueTaxpayerReference)
+
+  }
+
+}

--- a/app/controllers/CheckDetailsController.scala
+++ b/app/controllers/CheckDetailsController.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.addFinancialInstitution.IsRegisteredBusiness.CheckDetailsView
+
+class CheckDetailsController @Inject() (
+  override val messagesApi: MessagesApi,
+  identify: IdentifierAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  val controllerComponents: MessagesControllerComponents,
+  view: CheckDetailsView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+
+}

--- a/app/controllers/actions/CtUtrRetrievalAction.scala
+++ b/app/controllers/actions/CtUtrRetrievalAction.scala
@@ -51,7 +51,7 @@ class CtUtrRetrievalActionProvider @Inject() (
 
     ctUtr match {
       case Some(_) =>
-        block(request.copy(autoMatched = true))
+        block(request.copy(autoMatched = true, ctutr = ctUtr))
       case _ =>
         block(request)
     }

--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -31,7 +31,7 @@ class DataRequiredActionImpl @Inject() (implicit val executionContext: Execution
       case None =>
         Future.successful(Left(Redirect(routes.JourneyRecoveryController.onPageLoad())))
       case Some(data) =>
-        Future.successful(Right(DataRequest(request.request, request.userId, request.fatcaId, data)))
+        Future.successful(Right(DataRequest(request.request, request.userId, request.fatcaId, data, request.ctutr)))
     }
 
 }

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -30,7 +30,7 @@ class DataRetrievalActionImpl @Inject() (
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
     sessionRepository.get(request.userId).map {
-      OptionalDataRequest(request.request, request.userId, request.fatcaId, _)
+      OptionalDataRequest(request.request, request.userId, request.fatcaId, _, request.ctutr)
     }
 
 }

--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
@@ -17,14 +17,17 @@
 package controllers.addFinancialInstitution.registeredBusiness
 
 import controllers.actions._
+import controllers.routes
 import forms.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectFormProvider
 import models.Mode
 import navigation.Navigator
-import pages.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectPage
+import pages.addFinancialInstitution.IsRegisteredBusiness.{FetchedRegisteredAddressPage, IsTheAddressCorrectPage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
+import services.RegistrationWithUtrService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.AddressHelper.formatAddressBlock
 import utils.ContactHelper
 import views.html.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectView
 
@@ -39,6 +42,8 @@ class IsTheAddressCorrectController @Inject() (
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
   formProvider: IsTheAddressCorrectFormProvider,
+  regService: RegistrationWithUtrService,
+  retrieveCtUTR: CtUtrRetrievalAction,
   val controllerComponents: MessagesControllerComponents,
   view: IsTheAddressCorrectView
 )(implicit ec: ExecutionContext)
@@ -48,24 +53,44 @@ class IsTheAddressCorrectController @Inject() (
 
   val form = formProvider()
 
-  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen retrieveCtUTR() andThen getData andThen requireData).async {
     implicit request =>
-      val preparedForm = request.userAnswers.get(IsTheAddressCorrectPage) match {
-        case None        => form
-        case Some(value) => form.fill(value)
+      request.ctutr match {
+        case Some(utr) =>
+          regService.fetchAddress(utr).flatMap {
+            address =>
+              for {
+                updatedAnswers <- Future.fromTry(request.userAnswers.set(FetchedRegisteredAddressPage, address))
+                result <- sessionRepository.set(updatedAnswers).map {
+                  _ =>
+                    val preparedForm = request.userAnswers.get(IsTheAddressCorrectPage) match {
+                      case None        => form
+                      case Some(value) => form.fill(value)
+                    }
+                    Ok(view(preparedForm, mode, getFinancialInstitutionName(request.userAnswers), formatAddressBlock(address).value))
+                }
+              } yield result
+
+          }
+        case None =>
+          println("SOMMIT WENT WRONG")
+          Future.successful(Redirect(routes.JourneyRecoveryController.onPageLoad()))
       }
 
-      Ok(view(preparedForm, mode, getFinancialInstitutionName(request.userAnswers)))
   }
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
+      val address = getFetchedAddress(request.userAnswers)
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, getFinancialInstitutionName(request.userAnswers)))),
+          formWithErrors =>
+            Future
+              .successful(BadRequest(view(formWithErrors, mode, getFinancialInstitutionName(request.userAnswers), formatAddressBlock(address).value))),
           value =>
             for {
+
               updatedAnswers <- Future.fromTry(request.userAnswers.set(IsTheAddressCorrectPage, value))
               _              <- sessionRepository.set(updatedAnswers)
             } yield Redirect(navigator.nextPage(IsTheAddressCorrectPage, mode, updatedAnswers))

--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
@@ -27,7 +27,6 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.RegistrationWithUtrService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import utils.AddressHelper.formatAddressBlock
 import utils.ContactHelper
 import views.html.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectView
 
@@ -67,7 +66,7 @@ class IsTheAddressCorrectController @Inject() (
                       case None        => form
                       case Some(value) => form.fill(value)
                     }
-                    Ok(view(preparedForm, mode, getFinancialInstitutionName(request.userAnswers), formatAddressBlock(address).value))
+                    Ok(view(preparedForm, mode, getFinancialInstitutionName(request.userAnswers), address))
                 }
               } yield result
 
@@ -91,7 +90,7 @@ class IsTheAddressCorrectController @Inject() (
               .fold(
                 formWithErrors =>
                   Future
-                    .successful(BadRequest(view(formWithErrors, mode, getFinancialInstitutionName(request.userAnswers), formatAddressBlock(address).value))),
+                    .successful(BadRequest(view(formWithErrors, mode, getFinancialInstitutionName(request.userAnswers), address))),
                 value =>
                   for {
 

--- a/app/models/AddressResponse.scala
+++ b/app/models/AddressResponse.scala
@@ -25,9 +25,20 @@ case class AddressResponse(
   addressLine4: Option[String],
   postalCode: Option[String],
   countryCode: String
-)
+) {
+
+  def lines: Seq[String] = Seq(
+    Some(addressLine1),
+    addressLine2,
+    addressLine3,
+    addressLine4,
+    postalCode,
+    Some(countryCode)
+  ).flatten
+
+}
 
 object AddressResponse {
 
-  implicit val format: Format[AddressResponse] = Json.format[AddressResponse]
+  implicit val format: OFormat[AddressResponse] = Json.format[AddressResponse]
 }

--- a/app/models/AddressResponse.scala
+++ b/app/models/AddressResponse.scala
@@ -18,25 +18,6 @@ package models
 
 import play.api.libs.json._
 
-case class RegistrationInfo(safeId: SafeId, name: String, address: AddressResponse)
-
-object RegistrationInfo {
-
-  implicit val format: OFormat[RegistrationInfo] = Json.format[RegistrationInfo]
-}
-
-case class SafeId(value: String)
-
-object SafeId {
-
-  implicit val reads: Reads[SafeId] = __.read[String].map(SafeId.apply)
-
-  implicit val writes: Writes[SafeId] = Writes(
-    safeId => JsString(safeId.value)
-  )
-
-}
-
 case class AddressResponse(
   addressLine1: String,
   addressLine2: Option[String],

--- a/app/models/RegistrationInfo.scala
+++ b/app/models/RegistrationInfo.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+
+case class RegistrationInfo(safeId: SafeId, name: String, address: AddressResponse)
+
+object RegistrationInfo {
+
+  implicit val format: OFormat[RegistrationInfo] = Json.format[RegistrationInfo]
+}
+
+case class SafeId(value: String)
+
+object SafeId {
+
+  implicit val reads: Reads[SafeId] = __.read[String].map(SafeId.apply)
+
+  implicit val writes: Writes[SafeId] = Writes(
+    safeId => JsString(safeId.value)
+  )
+
+}
+
+case class AddressResponse(
+  addressLine1: String,
+  addressLine2: Option[String],
+  addressLine3: Option[String],
+  addressLine4: Option[String],
+  postalCode: Option[String],
+  countryCode: String
+)
+
+object AddressResponse {
+
+  implicit val format: Format[AddressResponse] = Json.format[AddressResponse]
+}

--- a/app/models/UniqueTaxpayerReference.scala
+++ b/app/models/UniqueTaxpayerReference.scala
@@ -18,7 +18,7 @@ package models
 
 import play.api.libs.json._
 
-case class UniqueTaxpayerReference(uniqueTaxPayerReference: String)
+case class UniqueTaxpayerReference(value: String)
 
 object UniqueTaxpayerReference {
   implicit val format: OFormat[UniqueTaxpayerReference] = Json.format[UniqueTaxpayerReference]

--- a/app/models/registration/response/ApiError.scala
+++ b/app/models/registration/response/ApiError.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.registration.response
+
+import play.api.http.Status
+import play.api.http.Status.SERVICE_UNAVAILABLE
+import uk.gov.hmrc.http.HttpReads
+import uk.gov.hmrc.http.HttpReads.{is4xx, is5xx}
+
+sealed trait ApiError
+
+object ApiError {
+
+  implicit def readEitherOf[A: HttpReads]: HttpReads[Either[ApiError, A]] =
+    HttpReads.ask.flatMap {
+      case (_, _, response) =>
+        response.status match {
+          case status if status == 404                 => HttpReads.pure(Left(NotFoundError))
+          case status if is4xx(status)                 => HttpReads.pure(Left(BadRequestError))
+          case status if status == SERVICE_UNAVAILABLE => HttpReads.pure(Left(ServiceUnavailableError))
+          case status if is5xx(status)                 => HttpReads.pure(Left(InternalServerError))
+          case _                                       => HttpReads[A].map(Right.apply)
+        }
+    }
+
+  def convertToErrorCode(apiError: ApiError): Int =
+    apiError match {
+      case NotFoundError           => Status.NOT_FOUND
+      case BadRequestError         => Status.BAD_REQUEST
+      case ServiceUnavailableError => Status.SERVICE_UNAVAILABLE
+      case _                       => Status.INTERNAL_SERVER_ERROR
+    }
+
+  case object BadRequestError extends ApiError
+
+  case object NotFoundError extends ApiError
+
+  case object ServiceUnavailableError extends ApiError
+
+  case object InternalServerError extends ApiError
+
+  case class MandatoryInformationMissingError(value: String = "") extends ApiError
+
+  case object DuplicateSubmissionError extends ApiError
+
+  case object UnableToCreateEMTPSubscriptionError extends ApiError
+
+  case object UnableToCreateEnrolmentError extends ApiError
+
+}

--- a/app/models/requests/DataRequest.scala
+++ b/app/models/requests/DataRequest.scala
@@ -17,8 +17,14 @@
 package models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
-import models.UserAnswers
+import models.{UniqueTaxpayerReference, UserAnswers}
 
-case class OptionalDataRequest[A](request: Request[A], userId: String, fatcaId: String, userAnswers: Option[UserAnswers]) extends WrappedRequest[A](request)
+case class OptionalDataRequest[A](request: Request[A],
+                                  userId: String,
+                                  fatcaId: String,
+                                  userAnswers: Option[UserAnswers],
+                                  ctutr: Option[UniqueTaxpayerReference]
+) extends WrappedRequest[A](request)
 
-case class DataRequest[A](request: Request[A], userId: String, fatcaId: String, userAnswers: UserAnswers) extends WrappedRequest[A](request)
+case class DataRequest[A](request: Request[A], userId: String, fatcaId: String, userAnswers: UserAnswers, ctutr: Option[UniqueTaxpayerReference])
+    extends WrappedRequest[A](request)

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -16,6 +16,7 @@
 
 package models.requests
 
+import models.UniqueTaxpayerReference
 import play.api.mvc.{Request, WrappedRequest}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment}
 
@@ -24,5 +25,6 @@ case class IdentifierRequest[A](request: Request[A],
                                 fatcaId: String,
                                 userType: AffinityGroup,
                                 enrolments: Set[Enrolment] = Set.empty,
-                                autoMatched: Boolean = false
+                                autoMatched: Boolean = false,
+                                ctutr: Option[UniqueTaxpayerReference] = None
 ) extends WrappedRequest[A](request)

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -19,7 +19,7 @@ package navigation
 import controllers.addFinancialInstitution.routes
 import models._
 import pages._
-import pages.addFinancialInstitution.IsRegisteredBusiness.{IsThisYourBusinessNamePage, ReportForRegisteredBusinessPage}
+import pages.addFinancialInstitution.IsRegisteredBusiness.{IsTheAddressCorrectPage, IsThisYourBusinessNamePage, ReportForRegisteredBusinessPage}
 import pages.addFinancialInstitution._
 import play.api.mvc.Call
 
@@ -140,6 +140,14 @@ class Navigator @Inject() () {
           IsThisYourBusinessNamePage,
           routes.SendReportsController.onPageLoad(NormalMode),
           routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
+        )
+    case IsTheAddressCorrectPage =>
+      userAnswers =>
+        yesNoPage(
+          userAnswers,
+          IsTheAddressCorrectPage,
+          controllers.routes.CheckDetailsController.onPageLoad(),
+          routes.WhereIsFIBasedController.onPageLoad(NormalMode)
         )
     case UkAddressPage    => _ => routes.FirstContactNameController.onPageLoad(NormalMode)
     case NonUkAddressPage => _ => routes.FirstContactNameController.onPageLoad(NormalMode)

--- a/app/pages/addFinancialInstitution/IsRegisteredBusiness/FetchedRegisteredAddressPage.scala
+++ b/app/pages/addFinancialInstitution/IsRegisteredBusiness/FetchedRegisteredAddressPage.scala
@@ -14,19 +14,14 @@
  * limitations under the License.
  */
 
-package controllers.actions
+package pages.addFinancialInstitution.IsRegisteredBusiness
 
-import models.UserAnswers
-import models.requests.{IdentifierRequest, OptionalDataRequest}
+import models.AddressResponse
+import pages.QuestionPage
+import play.api.libs.json.JsPath
 
-import scala.concurrent.{ExecutionContext, Future}
+case object FetchedRegisteredAddressPage extends QuestionPage[AddressResponse] {
 
-class FakeDataRetrievalAction(dataToReturn: Option[UserAnswers]) extends DataRetrievalAction {
-
-  override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
-    Future(OptionalDataRequest(request.request, request.userId, request.fatcaId, dataToReturn, request.ctutr))
-
-  implicit override protected val executionContext: ExecutionContext =
-    scala.concurrent.ExecutionContext.Implicits.global
+  override def path: JsPath = JsPath \ toString
 
 }

--- a/app/services/RegistrationWithUtrService.scala
+++ b/app/services/RegistrationWithUtrService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,27 +14,21 @@
  * limitations under the License.
  */
 
-package connectors
+package services
 
-import config.FrontendAppConfig
-import models.RegistrationInfo
+import connectors.RegistrationWithUtrConnector
+import models.{AddressResponse, UniqueTaxpayerReference}
 import play.api.Logging
-import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.HeaderCarrier
 
-import java.net.URL
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class RegistrationWithUtrConnector @Inject() (val config: FrontendAppConfig, val http: HttpClient) extends Logging {
+class RegistrationWithUtrService @Inject()(val connector: RegistrationWithUtrConnector) extends Logging {
 
-  def sendAndRetrieveRegWithUtr(
-    uniqueTaxpayerReference: String
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[RegistrationInfo] = {
+  def fetchAddress(utr: UniqueTaxpayerReference)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[AddressResponse] =
+    connector.sendAndRetrieveRegWithUtr(utr.value).map(_.address)
 
-    val endpoint = new URL(s"${config.registrationUrl}/crs-fatca-registration/registration/v2/organisation/utr")
 
-    http.POST[String, RegistrationInfo](endpoint, uniqueTaxpayerReference)
-
-  }
 
 }

--- a/app/services/RegistrationWithUtrService.scala
+++ b/app/services/RegistrationWithUtrService.scala
@@ -38,7 +38,7 @@ class RegistrationWithUtrService @Inject() (val connector: RegistrationWithUtrCo
   private def extractAddress(body: String): AddressResponse = {
     val json: JsValue                            = Json.parse(body)
     val addressResult: JsResult[AddressResponse] = (json \ "registerWithIDResponse" \ "responseDetail" \ "address").validate[AddressResponse]
-    addressResult.get // is need to cover the error?
+    addressResult.get
 
   }
 

--- a/app/services/RegistrationWithUtrService.scala
+++ b/app/services/RegistrationWithUtrService.scala
@@ -19,7 +19,7 @@ package services
 import connectors.RegistrationWithUtrConnector
 import models.{AddressResponse, UniqueTaxpayerReference}
 import play.api.Logging
-import play.api.libs.json.{JsError, JsResult, JsSuccess, JsValue, Json}
+import play.api.libs.json.{JsResult, JsValue, Json}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.Inject

--- a/app/utils/AddressHelper.scala
+++ b/app/utils/AddressHelper.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import models.{Address, AddressLookup}
+import models.{Address, AddressLookup, AddressResponse}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 
 object AddressHelper {
@@ -67,6 +67,20 @@ object AddressHelper {
         case s: String => s
         case Some(s)   => s
       }
+    createHtmlBlock(lines)
+
+  }
+
+  def formatAddressBlock(address: AddressResponse): HtmlContent = {
+    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postalCode) // missing country
+      .collect {
+        case s: String => s
+        case Some(s)   => s
+      }
+    createHtmlBlock(lines)
+  }
+
+  private def createHtmlBlock(lines: Seq[Any]) = {
     val block = lines
       .map(
         line => s"<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>$line</p>"

--- a/app/utils/AddressHelper.scala
+++ b/app/utils/AddressHelper.scala
@@ -16,7 +16,7 @@
 
 package utils
 
-import models.{Address, AddressLookup, AddressResponse}
+import models.{Address, AddressLookup}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 
 object AddressHelper {
@@ -67,20 +67,6 @@ object AddressHelper {
         case s: String => s
         case Some(s)   => s
       }
-    createHtmlBlock(lines)
-
-  }
-
-  def formatAddressBlock(address: AddressResponse): HtmlContent = {
-    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postalCode, address.countryCode)
-      .collect {
-        case s: String => s
-        case Some(s)   => s
-      }
-    createHtmlBlock(lines)
-  }
-
-  private def createHtmlBlock(lines: Seq[Any]) = {
     val block = lines
       .map(
         line => s"<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>$line</p>"

--- a/app/utils/AddressHelper.scala
+++ b/app/utils/AddressHelper.scala
@@ -72,7 +72,7 @@ object AddressHelper {
   }
 
   def formatAddressBlock(address: AddressResponse): HtmlContent = {
-    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postalCode) // missing country
+    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postalCode, address.countryCode)
       .collect {
         case s: String => s
         case Some(s)   => s

--- a/app/viewmodels/checkAnswers/WhatIsUniqueTaxpayerReferenceSummary.scala
+++ b/app/viewmodels/checkAnswers/WhatIsUniqueTaxpayerReferenceSummary.scala
@@ -32,7 +32,7 @@ object WhatIsUniqueTaxpayerReferenceSummary {
       answer =>
         SummaryListRowViewModel(
           key = "whatIsUniqueTaxpayerReference.checkYourAnswersLabel",
-          value = ValueViewModel(HtmlFormat.escape(answer.uniqueTaxPayerReference).toString),
+          value = ValueViewModel(HtmlFormat.escape(answer.value).toString),
           actions = Seq(
             accessibleActionItem("site.change", controllers.addFinancialInstitution.routes.WhatIsUniqueTaxpayerReferenceController.onPageLoad(CheckMode).url)
               .withVisuallyHiddenText(messages("whatIsUniqueTaxpayerReference.change.hidden"))

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/CheckDetailsView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/CheckDetailsView.scala.html
@@ -1,0 +1,27 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("checkDetails.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("checkDetails.heading")</h1>
+}

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
@@ -23,9 +23,10 @@
     govukRadios: GovukRadios,
     govukButton: GovukButton,
     heading: Heading,
+    addressBlock: AddressBlock
 )
 
-@(form: Form[_], mode: Mode, fiName: String, addressBlock: Html)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, fiName: String, address: AddressResponse)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("isTheAddressCorrect.title", fiName))) {
 
@@ -37,7 +38,7 @@
 
         @heading(messages("isTheAddressCorrect.heading", fiName))
 
-       <div class="govuk-body">@addressBlock</div>
+       @addressBlock(addressRes = Some(address))
 
         @govukRadios(
             RadiosViewModel.yesNo(

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
@@ -14,15 +14,18 @@
  * limitations under the License.
  *@
 
+@import components._
+
 @this(
     layout: templates.Layout,
     formHelper: FormWithCSRF,
     govukErrorSummary: GovukErrorSummary,
     govukRadios: GovukRadios,
-    govukButton: GovukButton
+    govukButton: GovukButton,
+    heading: Heading,
 )
 
-@(form: Form[_], mode: Mode, fiName: String)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, fiName: String, addressBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("isTheAddressCorrect.title", fiName))) {
 
@@ -32,10 +35,14 @@
             @govukErrorSummary(ErrorSummaryViewModel(form))
         }
 
+        @heading(messages("isTheAddressCorrect.heading", fiName))
+
+       <div class="govuk-body">@addressBlock</div>
+
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(messages("isTheAddressCorrect.heading", fiName)).asPageHeading()
+                legend = LegendViewModel(messages("isTheAddressCorrect.heading", fiName)).withCssClass("govuk-visually-hidden")
             )
         )
 

--- a/app/views/addFinancialInstitution/IsThisAddressView.scala.html
+++ b/app/views/addFinancialInstitution/IsThisAddressView.scala.html
@@ -40,7 +40,7 @@
 
         @heading(messages("isThisAddress.heading", fiName))
 
-        @addressBlock(address)
+        @addressBlock(address = Some(address))
 
         @govukRadios(
             RadiosViewModel.yesNo(

--- a/app/views/components/AddressBlock.scala.html
+++ b/app/views/components/AddressBlock.scala.html
@@ -18,13 +18,22 @@
 
 @this()
 
-@(address: Address, classes: String = "govuk-body")
+@(address: Option[Address] = None, addressRes: Option[AddressResponse]= None, classes: String = "govuk-body")
 
-@lines = @{address.lines.map {
-    case line       => s"<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>$line</p>"
-    case _          => ""
-    }.mkString("")
-}
+
+@lines = @{
+    val rows = (address.isDefined, addressRes.isDefined) match {
+      case (true, _) => address.get.lines
+      case (_, true) => addressRes.get.lines
+    }
+    rows.map {
+        case line => s"<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>$line</p>"
+        case _    => ""
+      }
+      .mkString("")
+  }
+
+
 <div class= "@classes">
     @Html(lines)
 </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -144,4 +144,4 @@ POST       /registered-business/is-this-your-business-name           controllers
 GET        /registered-business/change-is-this-your-business-name    controllers.addFinancialInstitution.registeredBusiness.IsThisYourBusinessNameController.onPageLoad(mode: Mode = CheckMode)
 POST       /registered-business/change-is-this-your-business-name    controllers.addFinancialInstitution.registeredBusiness.IsThisYourBusinessNameController.onSubmit(mode: Mode = CheckMode)
 
-
+GET        /registered-business/check-answers                        controllers.CheckDetailsController.onPageLoad()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -255,7 +255,7 @@ ukAddress.error.postcode.chars = Postcode must only include letters a to z and n
 ukAddress.error.postcode.invalid = Enter a real postcode
 ukAddress.error.country.required = Select country
 
-isTheAddressCorrect.title = Is this the registered address for {0}?
+isTheAddressCorrect.title = Is this the registered address for the financial institution?
 isTheAddressCorrect.heading = Is this the registered address for {0}?
 isTheAddressCorrect.checkYourAnswersLabel = isTheAddressCorrect
 isTheAddressCorrect.error.required = Select yes if the registered address for the financial institution is correct

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -321,3 +321,5 @@ postcode.continue = Find address
 mainAddress.checkYourAnswersLabel = Main business address
 mainAddress.change.hidden = Change main business address
 
+checkDetails.title = checkDetails
+checkDetails.heading = checkDetails

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -36,6 +36,58 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
   val userAnswersId: String = "FATCAID"
   val fiName                = "Financial Institution"
 
+  private val safeId    = "XE0000123456789"
+  private val OrgName   = "Some Test Org"
+  private val TestEmail = "test@test.com"
+
+  val orgRegWithUtrResponse: String =
+    s"""
+       |{
+       |"registerWithIDResponse": {
+       |"responseCommon": {
+       |"status": "OK",
+       |"statusText": "Sample status text",
+       |"processingDate": "2016-08-16T15:55:30Z",
+       |"returnParameters": [
+       |{
+       |"paramName":
+       |"SAP_NUMBER",
+       |"paramValue":
+       |"0123456789"
+       |}
+       |]
+       |},
+       |"responseDetail": {
+       |"SAFEID": "$safeId",
+       |"ARN": "WARN8764123",
+       |"isEditable": true,
+       |"isAnAgent": false,
+       |"isAnIndividual": true,
+       |"organisation": {
+       |"organisationName": "$OrgName",
+       |"isAGroup": false,
+       |"organisationType": "0001"
+       |},
+       |"address": {
+       |"addressLine1": "100 Parliament Street",
+       |"addressLine4": "London",
+       |"postalCode": "SW1A 2BQ",
+       |"countryCode": "GB"
+       |},
+       |"contactDetails": {
+       |"phoneNumber":
+       |"1111111",
+       |"mobileNumber":
+       |"2222222",
+       |"faxNumber":
+       |"1111111",
+       |"emailAddress":
+       |"$TestEmail"
+       |}
+       |}
+       |}
+       |}""".stripMargin
+
   implicit val hc: HeaderCarrier    = HeaderCarrier()
   def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId)
 

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,7 +17,7 @@
 package base
 
 import controllers.actions._
-import models.UserAnswers
+import models.{Address, AddressResponse, Country, UserAnswers}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -87,6 +87,9 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
        |}
        |}
        |}""".stripMargin
+
+  val testAddress: Address                 = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
+  val testAddressResponse: AddressResponse = AddressResponse("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB.code)
 
   implicit val hc: HeaderCarrier    = HeaderCarrier()
   def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId)

--- a/test/connectors/RegistrationWithUtrConnectorSpec.scala
+++ b/test/connectors/RegistrationWithUtrConnectorSpec.scala
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, urlEqua
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import generators.Generators
 import helpers.WireMockServerHandler
+import models.UniqueTaxpayerReference
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.http.Status._
@@ -37,10 +38,10 @@ class RegistrationWithUtrConnectorSpec extends SpecBase with WireMockServerHandl
     .build()
 
   lazy val connector: RegistrationWithUtrConnector = application.injector.instanceOf[RegistrationWithUtrConnector]
-  val endpoint                                     = "/v2/organisation/utr"
+  val endpoint                                     = "/organisation/utr-only"
 
   "sendAndRetrieveRegWithUtr" - {
-    val utr: String = "1112223330"
+    val utr = UniqueTaxpayerReference("1112223330")
 
     "return 200 and a registration response when organisation is matched by utr" in {
 

--- a/test/connectors/RegistrationWithUtrConnectorSpec.scala
+++ b/test/connectors/RegistrationWithUtrConnectorSpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, urlEqualTo}
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import generators.Generators
+import helpers.WireMockServerHandler
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.Application
+import play.api.http.Status._
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class RegistrationWithUtrConnectorSpec extends SpecBase with WireMockServerHandler with Generators with ScalaCheckPropertyChecks {
+
+  lazy val application: Application = new GuiceApplicationBuilder()
+    .configure(
+      conf = "microservice.services.crs-fatca-registration.port" -> server.port()
+    )
+    .build()
+
+  lazy val connector: RegistrationWithUtrConnector = application.injector.instanceOf[RegistrationWithUtrConnector]
+  val endpoint                                     = "/v2/organisation/utr"
+
+  "sendAndRetrieveRegWithUtr" - {
+    val utr: String = "1112223330"
+
+    "return 200 and a registration response when organisation is matched by utr" in {
+
+      stubResponse(endpoint, OK, orgRegWithUtrResponse)
+      val result = connector.sendAndRetrieveRegWithUtr(utr)
+      result.futureValue.status mustBe 200
+      result.futureValue.body mustBe orgRegWithUtrResponse
+    }
+
+    "return 404 and NotFoundError when there is no match" in {
+
+      stubResponse(endpoint, NOT_FOUND, orgRegWithUtrResponse)
+
+      val result = connector.sendAndRetrieveRegWithUtr(utr)
+      assertThrows[Exception] {
+        result.futureValue
+      }
+
+    }
+
+    "return 503 and ServiceUnavailableError when remote is unavailable " in {
+
+      stubResponse(endpoint, SERVICE_UNAVAILABLE, orgRegWithUtrResponse)
+
+      val result = connector.sendAndRetrieveRegWithUtr(utr)
+      assertThrows[Exception] {
+        result.futureValue
+      }
+
+    }
+  }
+
+  private def stubResponse(expectedEndpoint: String, expectedStatus: Int, expectedBody: String): StubMapping = {
+    val registrationUrl = "/crs-fatca-registration/registration"
+
+    server.stubFor(
+      post(urlEqualTo(s"$registrationUrl$expectedEndpoint"))
+        .willReturn(
+          aResponse()
+            .withStatus(expectedStatus)
+            .withBody(expectedBody)
+        )
+    )
+  }
+
+}

--- a/test/controllers/CheckDetailsControllerSpec.scala
+++ b/test/controllers/CheckDetailsControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase

--- a/test/controllers/CheckDetailsControllerSpec.scala
+++ b/test/controllers/CheckDetailsControllerSpec.scala
@@ -1,0 +1,29 @@
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.addFinancialInstitution.IsRegisteredBusiness.CheckDetailsView
+
+class CheckDetailsControllerSpec extends SpecBase {
+
+  "CheckDetails Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.CheckDetailsController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CheckDetailsView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(request, messages(application)).toString
+      }
+    }
+  }
+
+}

--- a/test/controllers/actions/FakeCtUtrRetrievalAction.scala
+++ b/test/controllers/actions/FakeCtUtrRetrievalAction.scala
@@ -16,6 +16,7 @@
 
 package controllers.actions
 
+import models.UniqueTaxpayerReference
 import models.requests.IdentifierRequest
 import play.api.mvc._
 
@@ -31,7 +32,7 @@ class FakeCtUtrRetrievalActionProvider extends CtUtrRetrievalAction {
 class FakeCtUtrRetrievalAction extends ActionFunction[IdentifierRequest, IdentifierRequest] {
 
   override def invokeBlock[A](request: IdentifierRequest[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
-    block(request.copy(autoMatched = true))
+    block(request.copy(autoMatched = true, ctutr = Some(UniqueTaxpayerReference("1234567890"))))
 
   implicit override protected val executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global

--- a/test/controllers/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectControllerSpec.scala
@@ -34,7 +34,6 @@ import play.api.test.Helpers._
 import repositories.SessionRepository
 import services.RegistrationWithUtrService
 import uk.gov.hmrc.http.HeaderCarrier
-import utils.AddressHelper.formatAddressBlock
 import views.html.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,7 +44,7 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
 
   val formProvider = new IsTheAddressCorrectFormProvider()
   val form         = formProvider()
-  val address      = formatAddressBlock(testAddressResponse).value
+  val address      = testAddressResponse
 
   val userAnswersWithName = UserAnswers(userAnswersId)
     .withPage(NameOfFinancialInstitutionPage, fiName)

--- a/test/controllers/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectControllerSpec.scala
@@ -47,7 +47,7 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
   val form         = formProvider()
   val address      = formatAddressBlock(testAddressResponse).value
 
-  val uaWithNameAndUtr = UserAnswers(userAnswersId)
+  val userAnswersWithName = UserAnswers(userAnswersId)
     .withPage(NameOfFinancialInstitutionPage, fiName)
 
   lazy val isTheAddressCorrectRoute: String =
@@ -67,9 +67,7 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
 
     "must return OK and the correct view for a GET" in {
 
-      val userAnswers = uaWithNameAndUtr
-
-      val application = applicationBuilder(userAnswers = Some(userAnswers))
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithName))
         .overrides(bind[CtUtrRetrievalAction].toInstance(mockCtUtrRetrievalAction))
         .overrides(bind[SessionRepository].toInstance(mockSessionRepository))
         .overrides(bind[RegistrationWithUtrService].toInstance(mockRegService))
@@ -88,7 +86,7 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
-      val userAnswers = uaWithNameAndUtr
+      val userAnswers = userAnswersWithName
         .withPage(IsTheAddressCorrectPage, true)
 
       val application = applicationBuilder(userAnswers = Some(userAnswers))
@@ -110,9 +108,11 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
     }
 
     "must redirect to the next page when valid data is submitted" in {
+      val userAnswers = userAnswersWithName
+        .withPage(FetchedRegisteredAddressPage, testAddressResponse)
 
       val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+        applicationBuilder(userAnswers = Some(userAnswers))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
             bind[SessionRepository].toInstance(mockSessionRepository)
@@ -132,7 +132,8 @@ class IsTheAddressCorrectControllerSpec extends SpecBase with MockitoSugar {
     }
 
     "must return a Bad Request and errors when invalid data is submitted" in {
-      val userAnswers = uaWithNameAndUtr.withPage(FetchedRegisteredAddressPage, testAddressResponse)
+      val userAnswers = userAnswersWithName
+        .withPage(FetchedRegisteredAddressPage, testAddressResponse)
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.addFinancialInstitution.routes
 import models._
 import pages._
-import pages.addFinancialInstitution.IsRegisteredBusiness.{IsThisYourBusinessNamePage, ReportForRegisteredBusinessPage}
+import pages.addFinancialInstitution.IsRegisteredBusiness.{IsTheAddressCorrectPage, IsThisYourBusinessNamePage, ReportForRegisteredBusinessPage}
 import pages.addFinancialInstitution._
 
 class NavigatorSpec extends SpecBase {
@@ -185,71 +185,83 @@ class NavigatorSpec extends SpecBase {
           navigator.nextPage(WhatIsGIINPage, NormalMode, userAnswers) mustBe
             routes.WhereIsFIBasedController.onPageLoad(NormalMode)
         }
-
-        "must go from WhereIsFIBased to UKPostcode when user answers yes" in {
-          val userAnswers = emptyUserAnswers.withPage(WhereIsFIBasedPage, true)
-          navigator.nextPage(WhereIsFIBasedPage, NormalMode, userAnswers) mustBe
-            routes.PostcodeController.onPageLoad(NormalMode)
-        }
-
-        "must go from WhereIsFIBased to NonUKAddress when user answers no" in {
-          val userAnswers = emptyUserAnswers.withPage(WhereIsFIBasedPage, false)
-          navigator.nextPage(WhereIsFIBasedPage, NormalMode, userAnswers) mustBe
-            routes.NonUkAddressController.onPageLoad(NormalMode)
-        }
-
-        "must go from UkAddress to FirstContactName" in {
-          navigator.nextPage(UkAddressPage, NormalMode, emptyUserAnswers) mustBe
-            routes.FirstContactNameController.onPageLoad(NormalMode)
-        }
-
-        "must go from NonUkAddress to FirstContactName" in {
-          navigator.nextPage(NonUkAddressPage, NormalMode, emptyUserAnswers) mustBe
-            routes.FirstContactNameController.onPageLoad(NormalMode)
-        }
-
-        "must go from ReportForRegisteredBusiness" - {
-          " to IsThisYourBusinessName if Yes" in {
-            val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, true).get
-            navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
-              controllers.addFinancialInstitution.registeredBusiness.routes.IsThisYourBusinessNameController.onPageLoad(NormalMode)
-          }
-          " to NameOfFinancialInstitution if No" in {
-            val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, false).get
-            navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
-              routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
-          }
-        }
-
-        "must go from IsThisYourBusinessName" - {
-          " to SendReports if Yes" in {
-            val userAnswers = emptyUserAnswers.set(IsThisYourBusinessNamePage, true).get
-            navigator.nextPage(IsThisYourBusinessNamePage, NormalMode, userAnswers) mustBe
-              routes.SendReportsController.onPageLoad(NormalMode)
-          }
-          " to NameOfFinancialInstitution if No" in {
-            val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, false).get
-            navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
-              routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
-          }
-        }
-
       }
 
-      "in Check mode" - {
+      "must go from WhereIsFIBased to UKPostcode when user answers yes" in {
+        val userAnswers = emptyUserAnswers.withPage(WhereIsFIBasedPage, true)
+        navigator.nextPage(WhereIsFIBasedPage, NormalMode, userAnswers) mustBe
+          routes.PostcodeController.onPageLoad(NormalMode)
+      }
 
-        "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+      "must go from WhereIsFIBased to NonUKAddress when user answers no" in {
+        val userAnswers = emptyUserAnswers.withPage(WhereIsFIBasedPage, false)
+        navigator.nextPage(WhereIsFIBasedPage, NormalMode, userAnswers) mustBe
+          routes.NonUkAddressController.onPageLoad(NormalMode)
+      }
 
-          case object UnknownPage extends Page
-          navigator.nextPage(
-            UnknownPage,
-            CheckMode,
-            UserAnswers("id")
-          ) mustBe routes.CheckYourAnswersController.onPageLoad
+      "must go from UkAddress to FirstContactName" in {
+        navigator.nextPage(UkAddressPage, NormalMode, emptyUserAnswers) mustBe
+          routes.FirstContactNameController.onPageLoad(NormalMode)
+      }
+
+      "must go from NonUkAddress to FirstContactName" in {
+        navigator.nextPage(NonUkAddressPage, NormalMode, emptyUserAnswers) mustBe
+          routes.FirstContactNameController.onPageLoad(NormalMode)
+      }
+
+      "must go from ReportForRegisteredBusiness" - {
+        " to IsThisYourBusinessName if Yes" in {
+          val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, true).get
+          navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
+            controllers.addFinancialInstitution.registeredBusiness.routes.IsThisYourBusinessNameController.onPageLoad(NormalMode)
+        }
+        " to NameOfFinancialInstitution if No" in {
+          val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, false).get
+          navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
+            routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
         }
       }
+
+      "must go from IsThisYourBusinessName" - {
+        " to SendReports if Yes" in {
+          val userAnswers = emptyUserAnswers.set(IsThisYourBusinessNamePage, true).get
+          navigator.nextPage(IsThisYourBusinessNamePage, NormalMode, userAnswers) mustBe
+            routes.SendReportsController.onPageLoad(NormalMode)
+        }
+        " to NameOfFinancialInstitution if No" in {
+          val userAnswers = emptyUserAnswers.set(ReportForRegisteredBusinessPage, false).get
+          navigator.nextPage(ReportForRegisteredBusinessPage, NormalMode, userAnswers) mustBe
+            routes.NameOfFinancialInstitutionController.onPageLoad(NormalMode)
+        }
+      }
+
+      "must go from IsTheAddressCorrect" - {
+        " to checkDetails if Yes" in {
+          val userAnswers = emptyUserAnswers.set(IsTheAddressCorrectPage, true).get
+          navigator.nextPage(IsTheAddressCorrectPage, NormalMode, userAnswers) mustBe
+            controllers.routes.CheckDetailsController.onPageLoad()
+        }
+        " to WhereIsFiBased if No" in {
+          val userAnswers = emptyUserAnswers.set(IsTheAddressCorrectPage, false).get
+          navigator.nextPage(IsTheAddressCorrectPage, NormalMode, userAnswers) mustBe
+            routes.WhereIsFIBasedController.onPageLoad(NormalMode)
+        }
+      }
+
     }
 
+    "in Check mode" - {
+
+      "must go from a page that doesn't exist in the edit route map to CheckYourAnswers" in {
+
+        case object UnknownPage extends Page
+        navigator.nextPage(
+          UnknownPage,
+          CheckMode,
+          UserAnswers("id")
+        ) mustBe routes.CheckYourAnswersController.onPageLoad
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Jira: [DAC6-3231](https://jira.tools.tax.service.gov.uk/browse/DAC6-3231)

-introduces a connector and service to POST to crs-fatca-registration with a utr
-/is-the-address-correct displays the address from the response
-look and feel of this page plus navigation from this page
-scaffolded a placeholder 'checkDetails' (to be developed in another ticket)
-Controller saves fetched address in a Page object