### PR TITLE
DAC6-3336: Fix css class for default back link

### DIFF
--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -78,7 +78,7 @@
 
     @{
         if (showBackLink) {
-            val backLinkCssClass = if (backLink.equalsIgnoreCase("#")) ".govuk-default-back-link js-visible" else "js-visible"
+            val backLinkCssClass = if (backLink.equalsIgnoreCase("#")) "govuk-default-back-link js-visible" else "js-visible"
             govukBackLink(BackLinkViewModel(href = backLink).withCssClass(backLinkCssClass))
         }
     }


### PR DESCRIPTION
This PR fixes the css class used by the default back link