### PR TITLE
DAC6-3383: Update country code to GB

### DIFF
--- a/app/controllers/DetailsUpdatedController.scala
+++ b/app/controllers/DetailsUpdatedController.scala
@@ -25,7 +25,6 @@ import utils.ContactHelper
 import views.html.DetailsUpdatedView
 
 import javax.inject.Inject
-import scala.concurrent.Future
 
 class DetailsUpdatedController @Inject() (
   override val messagesApi: MessagesApi,

--- a/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
+++ b/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
@@ -20,7 +20,6 @@ import com.google.inject.Inject
 import controllers.actions._
 import models.{CheckAnswers, UserAnswers}
 import pages.Page
-import play.api.i18n.Lang.logger
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.FinancialInstitutionsService

--- a/app/controllers/addFinancialInstitution/IsThisAddressController.scala
+++ b/app/controllers/addFinancialInstitution/IsThisAddressController.scala
@@ -18,7 +18,7 @@ package controllers.addFinancialInstitution
 
 import controllers.actions._
 import forms.addFinancialInstitution.IsThisAddressFormProvider
-import models.{AddressLookup, Mode}
+import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{AddressLookupPage, IsThisAddressPage, SelectedAddressLookupPage}
 import play.api.i18n.{I18nSupport, MessagesApi}

--- a/app/handlers/ErrorHandler.scala
+++ b/app/handlers/ErrorHandler.scala
@@ -18,7 +18,7 @@ package handlers
 
 import config.FrontendAppConfig
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Request, RequestHeader}
+import play.api.mvc.RequestHeader
 import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 import views.html.{PageNotFoundView, ThereIsAProblemView}

--- a/app/models/AddressLookup.scala
+++ b/app/models/AddressLookup.scala
@@ -76,8 +76,9 @@ object AddressLookup {
       (JsPath \ "address" \ "county").readNullable[String] and
       (JsPath \ "address" \ "postcode").read[String] and
       (JsPath \ "address" \ "country" \ "code").readNullable[String] and
+      (JsPath \ "address" \ "country" \ "description").readNullable[String] and
       (JsPath \ "address" \ "country" \ "name").readNullable[String]) {
-      (lines, town, county, postcode, countryCode, countryName) =>
+      (lines, town, county, postcode, countryCode, countryDescription, countryName) =>
         val addressLines: (Option[String], Option[String], Option[String], Option[String]) =
           lines.size match {
             case 0 =>
@@ -98,7 +99,9 @@ object AddressLookup {
           town,
           county,
           postcode,
-          Some(Country("", countryCode.getOrElse("GB"), countryName.getOrElse("United Kingdom")))
+          countryCode.map(
+            code => Country("", code, countryDescription.orElse(countryName).getOrElse(code))
+          )
         )
     }
 

--- a/app/models/AddressLookup.scala
+++ b/app/models/AddressLookup.scala
@@ -28,7 +28,7 @@ case class AddressLookup(addressLine1: Option[String],
                          town: String,
                          county: Option[String],
                          postcode: String,
-                         country: Option[String]
+                         country: Option[Country]
 ) {
 
   val toAddress: Address = {
@@ -42,10 +42,9 @@ case class AddressLookup(addressLine1: Option[String],
       case (false, true) => Some(town)
       case (_, _)        => addressLine4
     }
-    val safePostcode  = Option(postcode)
-    val ctry: Country = Country("", "", country.getOrElse(""))
+    val safePostcode = Option(postcode)
 
-    Address(line1, line2, line3, line4, safePostcode, ctry)
+    Address(line1, line2, line3, line4, safePostcode, country.getOrElse(Country.GB))
   }
 
 }
@@ -76,11 +75,9 @@ object AddressLookup {
       (JsPath \ "address" \ "town").read[String] and
       (JsPath \ "address" \ "county").readNullable[String] and
       (JsPath \ "address" \ "postcode").read[String] and
-      (
-        (JsPath \ "address" \ "country").readNullable[String] orElse
-          (JsPath \ "address" \ "country" \ "name").readNullable[String]
-      )) {
-      (lines, town, county, postcode, countryName) =>
+      (JsPath \ "address" \ "country" \ "code").readNullable[String] and
+      (JsPath \ "address" \ "country" \ "name").readNullable[String]) {
+      (lines, town, county, postcode, countryCode, countryName) =>
         val addressLines: (Option[String], Option[String], Option[String], Option[String]) =
           lines.size match {
             case 0 =>
@@ -101,7 +98,7 @@ object AddressLookup {
           town,
           county,
           postcode,
-          countryName
+          Some(Country("", countryCode.getOrElse("GB"), countryName.getOrElse("United Kingdom")))
         )
     }
 

--- a/app/models/Country.scala
+++ b/app/models/Country.scala
@@ -22,7 +22,7 @@ case class Country(state: String, code: String, description: String)
 
 object Country {
 
-  val GB = Country("valid", "GB", "United Kingdom")
+  val GB = Country("", "GB", "United Kingdom")
 
   implicit val format: OFormat[Country] = Json.format[Country]
 }

--- a/app/models/FinancialInstitutions/FIDetail.scala
+++ b/app/models/FinancialInstitutions/FIDetail.scala
@@ -28,7 +28,7 @@ final case class FIDetail(
   IsFIUser: Boolean,
   IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
-  PrimaryContactDetails: ContactDetails,
+  PrimaryContactDetails: Option[ContactDetails],
   SecondaryContactDetails: Option[ContactDetails]
 )
 

--- a/app/utils/AddressHelper.scala
+++ b/app/utils/AddressHelper.scala
@@ -30,7 +30,7 @@ object AddressHelper {
       address.town,
       address.postcode,
       address.county,
-      address.country
+      address.country.map(_.description)
     )
       .collect {
         case s: String => s
@@ -40,14 +40,7 @@ object AddressHelper {
   }
 
   def formatAddress(address: Address): String = {
-    val lines = Seq(address.addressLine1,
-                    address.addressLine2,
-                    address.addressLine3,
-                    address.addressLine4,
-                    address.country,
-                    address.postCode,
-                    address.country.description
-    )
+    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postCode, address.country.description)
       .collect {
         case s: String => s
         case Some(s)   => s
@@ -64,20 +57,13 @@ object AddressHelper {
       address.town,
       address.postcode,
       address.county,
-      address.country
+      address.country.map(_.description)
     )
     toFormattedAddress(lines)
   }
 
   def formatAddressBlock(address: Address): HtmlContent = {
-    val lines = Seq(address.addressLine1,
-                    address.addressLine2,
-                    address.addressLine3,
-                    address.addressLine4,
-                    address.country,
-                    address.postCode,
-                    address.country.description
-    )
+    val lines = Seq(address.addressLine1, address.addressLine2, address.addressLine3, address.addressLine4, address.postCode, address.country.description)
     toFormattedAddress(lines)
   }
 

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -63,7 +63,7 @@ trait ModelGenerators extends RegexConstants with Generators {
         postCode     <- arbitrary[String]
         town         <- arbitrary[String]
         county       <- arbitrary[Option[String]]
-        country      <- arbitrary[Option[String]]
+        country      <- arbitrary[Option[Country]]
       } yield AddressLookup(addressLine1, addressLine2, addressLine3, addressLine4, town, county, postCode, country)
     }
 

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -137,7 +137,7 @@ trait ModelGenerators extends RegexConstants with Generators {
       IsFIUser = isFIUser,
       IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
-      PrimaryContactDetails = primaryContactDetails,
+      PrimaryContactDetails = Some(primaryContactDetails),
       SecondaryContactDetails = secondaryContactDetails
     )
   }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -100,7 +100,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
       IsFIUser = true,
       IsFATCAReporting = true,
       AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
-      ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888")),
+      Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
       Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
     )
 
@@ -114,7 +114,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         IsFIUser = true,
         IsFATCAReporting = true,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
-        ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888")),
+        Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
         Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
       ),
       FIDetail(
@@ -125,7 +125,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         IsFIUser = true,
         IsFATCAReporting = true,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
-        ContactDetails("Foo Bar", "fbar@example.com", Some("0223458888")),
+        Some(ContactDetails("Foo Bar", "fbar@example.com", Some("0223458888"))),
         Some(ContactDetails("Foobar Baz", "fbaz@example.com", Some("0123456789")))
       )
     )

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -207,7 +207,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
 
   val testAddress: Address                 = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
   val testAddressResponse: AddressResponse = AddressResponse("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB.code)
-  val testAddressLookup: AddressLookup     = AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some("United Kingdom"))
+  val testAddressLookup: AddressLookup     = AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some(Country.GB))
 
   implicit val hc: HeaderCarrier    = HeaderCarrier()
   def emptyUserAnswers: UserAnswers = UserAnswers(userAnswersId)

--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -59,7 +59,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
        |         "name": "England"
        |     },
        |     "country": {
-       |         "code": "UK",
+       |         "code": "GB",
        |         "name": "United Kingdom"
        |     }
        |  },
@@ -88,7 +88,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
         stubResponse(addressLookupUrl, OK, addressJson)
 
         val addressLookupResult = Seq(
-          AddressLookup(Some("1 Address line 1 Road"), None, Some("Address line 2 Road"), None, "Town", Some("County"), postcode, Some("United Kingdom"))
+          AddressLookup(Some("1 Address line 1 Road"), None, Some("Address line 2 Road"), None, "Town", Some("County"), postcode, Some(Country.GB))
         )
 
         val result = connector.addressLookupByPostcode(postcode)
@@ -154,7 +154,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -185,7 +185,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -215,7 +215,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -245,7 +245,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -275,7 +275,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -306,7 +306,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -336,7 +336,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -366,7 +366,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -396,7 +396,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -426,7 +426,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -456,7 +456,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -490,7 +490,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -521,7 +521,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -551,7 +551,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -581,7 +581,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -611,7 +611,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -641,7 +641,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -682,7 +682,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -713,7 +713,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -744,7 +744,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -775,7 +775,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -806,7 +806,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -837,7 +837,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -868,7 +868,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -899,7 +899,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -918,59 +918,27 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
         stubResponse(addressLookupUrl, OK, addressesJson)
 
         val addressLookupResult = Vector(
-          AddressLookup(Some("2 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("3 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("4 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("5 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("6 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Flat 1"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Flat 2"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Flat 3"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("8 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("9 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("10 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Suite 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Unit 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Suite 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Unit 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Suite 3"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Apartment 301"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("Apartment 302"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("Apartment 400"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("99-99a"),
-                        Some("Back High Street"),
-                        Some("Gosforth"),
-                        None,
-                        "Newcastle upon Tyne",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("135 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some("United Kingdom")),
+          AddressLookup(Some("2 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("3 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("4 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("5 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("6 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Flat 1"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Flat 2"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Flat 3"), Some("7 Other place"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("8 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("9 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("10 Other place"), None, Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Suite 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Unit 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Suite 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Unit 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Suite 3"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 301"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 302"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 400"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("99-99a"), Some("Back High Street"), Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("135 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some(Country.GB)),
           AddressLookup(Some("Efer House 137a"),
                         Some("Back High Street"),
                         Some("Gosforth"),
@@ -978,11 +946,11 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
                         "Newcastle upon Tyne",
                         Some("County"),
                         postcode,
-                        Some("United Kingdom")
+                        Some(Country.GB)
           ),
-          AddressLookup(Some("141 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("143 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("153 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some("United Kingdom"))
+          AddressLookup(Some("141 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("143 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("153 Back High Street"), None, Some("Gosforth"), None, "Newcastle upon Tyne", Some("County"), postcode, Some(Country.GB))
         )
 
         val result = connector.addressLookupByPostcode(postcode)
@@ -1009,7 +977,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1040,7 +1008,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1071,7 +1039,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1102,7 +1070,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1133,7 +1101,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1164,7 +1132,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1195,7 +1163,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1226,7 +1194,7 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
            |         "name": "England"
            |     },
            |     "country": {
-           |         "code": "UK",
+           |         "code": "GB",
            |         "name": "United Kingdom"
            |     }
            |  },
@@ -1245,38 +1213,14 @@ class AddressLookupConnectorSpec extends SpecBase with WireMockServerHandler wit
         stubResponse(addressLookupUrl, OK, addressesJsonv2)
 
         val addressLookupResult = Vector(
-          AddressLookup(Some("Suite 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Unit 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Suite 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Unit 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Suite 3"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some("United Kingdom")),
-          AddressLookup(Some("Apartment 301"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("Apartment 302"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          ),
-          AddressLookup(Some("Apartment 400"),
-                        Some("11 Waterloo Street"),
-                        Some("Some District"),
-                        None,
-                        "Town",
-                        Some("County"),
-                        postcode,
-                        Some("United Kingdom")
-          )
+          AddressLookup(Some("Suite 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Unit 1"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Suite 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Unit 2"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Suite 3"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 301"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 302"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB)),
+          AddressLookup(Some("Apartment 400"), Some("11 Waterloo Street"), Some("Some District"), None, "Town", Some("County"), postcode, Some(Country.GB))
         )
 
         val result = connector.addressLookupByPostcode(postcode)

--- a/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
@@ -47,7 +47,7 @@ class IsThisAddressControllerSpec extends SpecBase with MockitoSugar {
     addressLine3 = "Address town",
     addressLine4 = Some("Wessex"),
     postCode = Some("postcode"),
-    country = Country("valid", "GB", "United Kingdom")
+    country = Country.GB
   )
 
   val addressLookup: AddressLookup = AddressLookup(

--- a/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
@@ -58,7 +58,7 @@ class IsThisAddressControllerSpec extends SpecBase with MockitoSugar {
     town = "Address town",
     county = Some("Wessex"),
     postcode = "postcode",
-    country = Some("United Kingdom")
+    country = Some(Country.GB)
   )
 
   val userAnswers: UserAnswers = emptyUserAnswers.set(AddressLookupPage, Seq(addressLookup)).success.value

--- a/test/controllers/addFinancialInstitution/PostcodeControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/PostcodeControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.addFinancialInstitution
 import base.SpecBase
 import connectors.AddressLookupConnector
 import forms.addFinancialInstitution.PostcodeFormProvider
-import models.{AddressLookup, NormalMode}
+import models.{AddressLookup, Country, NormalMode}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
@@ -87,7 +87,7 @@ class PostcodeControllerSpec extends SpecBase with MockitoSugar {
       val mockAddressLookupConnector               = mock[AddressLookupConnector]
 
       val addresses: Seq[AddressLookup] = Seq(
-        AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some("Jersey")),
+        AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some(Country.GB)),
         AddressLookup(Some("2 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", None)
       )
 

--- a/test/controllers/addFinancialInstitution/SelectAddressControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/SelectAddressControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers.addFinancialInstitution
 
 import base.SpecBase
 import forms.addFinancialInstitution.SelectAddressFormProvider
-import models.{AddressLookup, NormalMode}
+import models.{AddressLookup, Country, NormalMode}
 import navigation.{FakeNavigator, Navigator}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -48,13 +48,13 @@ class SelectAddressControllerSpec extends SpecBase with MockitoSugar {
   private val ua  = emptyUserAnswers.set(NameOfFinancialInstitutionPage, contactName).get
 
   val addresses: Seq[AddressLookup] = Seq(
-    AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", None),
-    AddressLookup(Some("2 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", None)
+    AddressLookup(Some("1 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some(Country.GB)),
+    AddressLookup(Some("2 Address line 1"), None, None, None, "Town", None, "ZZ1 1ZZ", Some(Country.GB))
   )
 
   val addressOptions: Seq[RadioItem] = Seq(
-    RadioItem(content = Text("1 Address line 1, Town, ZZ1 1ZZ"), value = Some("1 Address line 1, Town, ZZ1 1ZZ")),
-    RadioItem(content = Text("2 Address line 1, Town, ZZ1 1ZZ"), value = Some("2 Address line 1, Town, ZZ1 1ZZ"))
+    RadioItem(content = Text("1 Address line 1, Town, ZZ1 1ZZ, United Kingdom"), value = Some("1 Address line 1, Town, ZZ1 1ZZ, United Kingdom")),
+    RadioItem(content = Text("2 Address line 1, Town, ZZ1 1ZZ, United Kingdom"), value = Some("2 Address line 1, Town, ZZ1 1ZZ, United Kingdom"))
   )
 
   val userAnswers = ua
@@ -107,7 +107,7 @@ class SelectAddressControllerSpec extends SpecBase with MockitoSugar {
 
       running(application) {
         val request =
-          FakeRequest(POST, SelectAddressRoute).withFormUrlEncodedBody(("value", "1 Address line 1, Town, ZZ1 1ZZ"))
+          FakeRequest(POST, SelectAddressRoute).withFormUrlEncodedBody(("value", "1 Address line 1, Town, ZZ1 1ZZ, United Kingdom"))
 
         val result = route(application, request).value
 

--- a/test/services/FinancialInstitutionUpdateServiceSpec.scala
+++ b/test/services/FinancialInstitutionUpdateServiceSpec.scala
@@ -217,7 +217,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             val populatedUserAnswers = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
-              .withPage(FirstContactHavePhonePage, fiDetails.PrimaryContactDetails.PhoneNumber.isEmpty)
+              .withPage(FirstContactHavePhonePage, fiDetails.PrimaryContactDetails.map(_.PhoneNumber).isEmpty)
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
         }
@@ -279,7 +279,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
         forAll {
           (fiDetails: FIDetail, name: String, email: String, phone: String) =>
             val fiDetailsWithSecondaryContact = fiDetails
-              .copy(PrimaryContactDetails = ContactDetails(name, email, PhoneNumber = Option(phone)))
+              .copy(PrimaryContactDetails = Some(ContactDetails(name, email, PhoneNumber = Option(phone))))
             when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
@@ -297,7 +297,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
         forAll {
           (fiDetails: FIDetail, name: String, email: String) =>
             val fiDetailsWithSecondaryContact = fiDetails
-              .copy(PrimaryContactDetails = ContactDetails(name, email, PhoneNumber = None))
+              .copy(PrimaryContactDetails = Some(ContactDetails(name, email, PhoneNumber = None)))
             when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
@@ -483,10 +483,10 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
     val addressPage = if (isUkAddress) UkAddressPage else NonUkAddressPage
     populatedUserAnswers.get(addressPage).value mustBe fiDetails.AddressDetails.toAddress(mockCountryListFactory).value
 
-    populatedUserAnswers.get(FirstContactNamePage).value mustBe fiDetails.PrimaryContactDetails.ContactName
-    populatedUserAnswers.get(FirstContactEmailPage).value mustBe fiDetails.PrimaryContactDetails.EmailAddress
-    populatedUserAnswers.get(FirstContactHavePhonePage).value mustBe fiDetails.PrimaryContactDetails.PhoneNumber.isDefined
-    populatedUserAnswers.get(FirstContactPhoneNumberPage) mustBe fiDetails.PrimaryContactDetails.PhoneNumber
+    populatedUserAnswers.get(FirstContactNamePage).value mustBe fiDetails.PrimaryContactDetails.map(_.ContactName).get
+    populatedUserAnswers.get(FirstContactEmailPage).value mustBe fiDetails.PrimaryContactDetails.map(_.EmailAddress).get
+    populatedUserAnswers.get(FirstContactHavePhonePage).value mustBe fiDetails.PrimaryContactDetails.map(_.PhoneNumber).isDefined
+    populatedUserAnswers.get(FirstContactPhoneNumberPage) mustBe fiDetails.PrimaryContactDetails.map(_.PhoneNumber).get
 
     populatedUserAnswers.get(SecondContactExistsPage).value mustBe fiDetails.SecondaryContactDetails.isDefined
     populatedUserAnswers.get(SecondContactNamePage) mustBe fiDetails.SecondaryContactDetails.map(_.ContactName)

--- a/test/utils/AddressHelperSpec.scala
+++ b/test/utils/AddressHelperSpec.scala
@@ -45,9 +45,9 @@ class AddressHelperSpec extends SpecBase {
     }
 
     "format the address from AddressLookup correctly" in {
-      val address = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some("country"))
+      val address = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
       val result  = sut.formatAddress(address)
-      result mustBe "line1, line2, line3, line4, town, postcode, county, country"
+      result mustBe "line1, line2, line3, line4, town, postcode, county, United Kingdom"
     }
 
     "format the address from AddressResponse correctly as html" in {
@@ -66,7 +66,7 @@ class AddressHelperSpec extends SpecBase {
     }
 
     "must format AddressLookupBlock as html" in {
-      val addressLookup = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some("country"))
+      val addressLookup = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
 
       val result = sut.formatAddressLookupBlock(addressLookup)
 
@@ -78,7 +78,7 @@ class AddressHelperSpec extends SpecBase {
             |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>${addressLookup.town}</p>
             |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>${addressLookup.postcode}</p>
             |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>${addressLookup.county.value}</p>
-            |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>${addressLookup.country.value}</p>
+            |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>${addressLookup.country.map(_.description).value}</p>
             |""".stripMargin.replaceAll("\\n", "")
       )
       result mustBe formattedAddress
@@ -87,24 +87,24 @@ class AddressHelperSpec extends SpecBase {
 
   "AddressLookup" - {
     "toAddress must convert to Address class" in {
-      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some("country"))
-      val expectedAddress = Address("line1", Some("line2"), "line3", Some("line4"), Some("postcode"), Country("", "", "country"))
+      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
+      val expectedAddress = Address("line1", Some("line2"), "line3", Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
     }
     "toAddress must populate from the town field correctly without line3" in {
-      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, Some("line4"), "town", Some("county"), "postcode", Some("country"))
-      val expectedAddress = Address("line1", Some("line2"), "town", Some("line4"), Some("postcode"), Country("", "", "country"))
+      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
+      val expectedAddress = Address("line1", Some("line2"), "town", Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
     }
     "toAddress must populate from the town field correctly without line4" in {
-      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), None, "town", Some("county"), "postcode", Some("country"))
-      val expectedAddress = Address("line1", Some("line2"), "line3", Some("town"), Some("postcode"), Country("", "", "country"))
+      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), None, "town", Some("county"), "postcode", Some(Country.GB))
+      val expectedAddress = Address("line1", Some("line2"), "line3", Some("town"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
 
     }
     "toAddress must populate county field if there is space" in {
-      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, None, "town", Some("county"), "postcode", Some("country"))
-      val expectedAddress = Address("line1", Some("line2"), "town", Some("county"), Some("postcode"), Country("", "", "country"))
+      val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, None, "town", Some("county"), "postcode", Some(Country.GB))
+      val expectedAddress = Address("line1", Some("line2"), "town", Some("county"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
 
     }


### PR DESCRIPTION
Refactor the country code from "UK" to "GB" in various models, tests, and utilities. This involves updating instances of "country" throughout AddressLookup, simplifying function and test case logic, and ensuring consistency in address formatting.