### PR TITLE
DAC6-3397: Update sbt plugins and configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,6 +56,7 @@ lazy val root = (project in file("."))
           "javascripts/app.js"
         ))
     ),
+    uglifyOps := UglifyOps.singleFile,
     // prevent removal of unused code which generates warning errors due to use of third-party libs
     uglifyCompressOptions := Seq("unused=false", "dead_code=false"),
     pipelineStages := Seq(digest),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,10 +20,10 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 
-addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.2.0")
+addSbtPlugin("com.github.sbt" % "sbt-concat" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "2.0.0")
+addSbtPlugin("com.github.sbt" % "sbt-uglify" % "3.0.1")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+addSbtPlugin("com.github.sbt" % "sbt-digest" % "2.0.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")


### PR DESCRIPTION
Upgraded sbt plugins for sbt-concat, sbt-uglify, and sbt-digest to newer versions. Added `uglifyOps` configuration in `build.sbt` to ensure single file minification.