### PR TITLE
BUILD_FIX: Add Country model import

### DIFF
--- a/test/connectors/AddressLookupConnectorSpec.scala
+++ b/test/connectors/AddressLookupConnectorSpec.scala
@@ -21,7 +21,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, post, urlEqua
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import generators.Generators
 import helpers.WireMockServerHandler
-import models.AddressLookup
+import models.{AddressLookup, Country}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.http.Status._


### PR DESCRIPTION
Included the Country model import to AddressLookupConnectorSpec to ensure the code has access to the necessary classes for address lookup functionality. This change is essential to support the expanded address lookup features.