### PR TITLE
DAC6-3379: Update CtUtrRetrievalAction && add unit tests

### DIFF
--- a/app/controllers/actions/CtUtrRetrievalAction.scala
+++ b/app/controllers/actions/CtUtrRetrievalAction.scala
@@ -21,6 +21,7 @@ import models.requests.IdentifierRequest
 import models.{IdentifierType, UniqueTaxpayerReference}
 import play.api.Logging
 import play.api.mvc.{ActionFunction, Result}
+import uk.gov.hmrc.auth.core.AffinityGroup
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -50,7 +51,7 @@ class CtUtrRetrievalActionProvider @Inject() (
       })
 
     ctUtr match {
-      case Some(_) =>
+      case Some(_) if request.userType != AffinityGroup.Agent =>
         block(request.copy(autoMatched = true, ctutr = ctUtr))
       case _ =>
         block(request)

--- a/test/controllers/actions/CtUtrRetrievalActionSpec.scala
+++ b/test/controllers/actions/CtUtrRetrievalActionSpec.scala
@@ -1,0 +1,50 @@
+package controllers.actions
+
+import base.SpecBase
+import config.FrontendAppConfig
+import models.requests.IdentifierRequest
+import org.mockito.MockitoSugar.when
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.Results.Ok
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CtUtrRetrievalActionSpec extends SpecBase with MockitoSugar {
+
+  implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  val mockAppConfig: FrontendAppConfig = mock[FrontendAppConfig]
+  val ctUtrEnrolment                   = Set(Enrolment("IR-CT", Seq(EnrolmentIdentifier("UTR", "1234567890")), "Activated"))
+  val orgRequest                       = IdentifierRequest(FakeRequest(), "FATCAID", "IR-CT", Organisation, ctUtrEnrolment)
+
+  "Ct Utr Retrieval Action" - {
+    "where is valid utr" - {
+      "should return automatched as true when affinity group not agent" in {
+        val ctUtrRetrievalAction = new CtUtrRetrievalActionProvider(mockAppConfig)
+        when(mockAppConfig.ctEnrolmentKey) thenReturn "IR-CT"
+
+        val result = ctUtrRetrievalAction.invokeBlock(orgRequest, (req: IdentifierRequest[_]) => Future.successful(Ok(s"${req.autoMatched}")))
+
+        status(result) mustBe OK
+        contentAsString(result) mustBe "true"
+      }
+
+      "should return automatched as false when affinity group is agent" in {
+        val ctUtrRetrievalAction = new CtUtrRetrievalActionProvider(mockAppConfig)
+        when(mockAppConfig.ctEnrolmentKey) thenReturn "IR-CT"
+
+        val agentRequest = orgRequest.copy(userType = Agent)
+
+        val result = ctUtrRetrievalAction.invokeBlock(agentRequest, (req: IdentifierRequest[_]) => Future.successful(Ok(s"${req.autoMatched}")))
+
+        status(result) mustBe OK
+        contentAsString(result) mustBe "false"
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Added tests for `CtUtrRetrievalAction` to ensure correct functionality. Validated auto-matching behavior for agents and non-agents, confirming correct responses.