### PR TITLE
DAC6-3293: Add cleanup flag to UserAnswers set method

### DIFF
--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -36,7 +36,7 @@ final case class UserAnswers(
   def get[A](page: Gettable[A])(implicit rds: Reads[A]): Option[A] =
     Reads.optionNoError(Reads.at(page.path)).reads(data).getOrElse(None)
 
-  def set[A](page: Settable[A], value: A)(implicit writes: Writes[A]): Try[UserAnswers] = {
+  def set[A](page: Settable[A], value: A, cleanup: Boolean = true)(implicit writes: Writes[A]): Try[UserAnswers] = {
 
     val updatedData = data.setObject(page.path, Json.toJson(value)) match {
       case JsSuccess(jsValue, _) =>
@@ -48,7 +48,11 @@ final case class UserAnswers(
     updatedData.flatMap {
       d =>
         val updatedAnswers = copy(data = d)
-        page.cleanup(Some(value), updatedAnswers)
+        if (cleanup) {
+          page.cleanup(Some(value), updatedAnswers)
+        } else {
+          Success(updatedAnswers)
+        }
     }
   }
 

--- a/app/services/FinancialInstitutionUpdateService.scala
+++ b/app/services/FinancialInstitutionUpdateService.scala
@@ -37,14 +37,14 @@ class FinancialInstitutionUpdateService @Inject() (
 
   def populateAndSaveFiDetails(userAnswers: UserAnswers, fiDetails: FIDetail): Future[UserAnswers] =
     for {
-      userAnswersWithProgressFlag <- Future.fromTry(userAnswers.set(ChangeFiDetailsInProgressId, fiDetails.FIID))
+      userAnswersWithProgressFlag <- Future.fromTry(userAnswers.set(ChangeFiDetailsInProgressId, fiDetails.FIID, cleanup = false))
       updatedUserAnswers          <- populateUserAnswersWithFiDetail(fiDetails, userAnswersWithProgressFlag)
       _                           <- sessionRepository.set(updatedUserAnswers)
     } yield updatedUserAnswers
 
   def populateAndSaveRegisteredFiDetails(userAnswers: UserAnswers, fiDetails: FIDetail): Future[UserAnswers] =
     for {
-      userAnswersWithProgressFlag <- Future.fromTry(userAnswers.set(ChangeFiDetailsInProgressId, fiDetails.FIID))
+      userAnswersWithProgressFlag <- Future.fromTry(userAnswers.set(ChangeFiDetailsInProgressId, fiDetails.FIID, cleanup = false))
       updatedUserAnswers          <- populateUserAnswersWithRegisteredFiDetail(fiDetails, userAnswersWithProgressFlag)
       _                           <- sessionRepository.set(updatedUserAnswers)
     } yield updatedUserAnswers
@@ -70,7 +70,7 @@ class FinancialInstitutionUpdateService @Inject() (
     userAnswers: UserAnswers
   )(implicit ec: ExecutionContext): Future[UserAnswers] =
     for {
-      a <- Future.fromTry(userAnswers.set(NameOfFinancialInstitutionPage, fiDetails.FIName))
+      a <- Future.fromTry(userAnswers.set(NameOfFinancialInstitutionPage, fiDetails.FIName, cleanup = false))
       b <- setUTR(a, fiDetails.TINDetails)
       c <- setGIIN(b, fiDetails.TINDetails)
       d <- setAddress(c, fiDetails.AddressDetails)
@@ -83,8 +83,8 @@ class FinancialInstitutionUpdateService @Inject() (
     userAnswers: UserAnswers
   )(implicit ec: ExecutionContext): Future[UserAnswers] =
     for {
-      a <- Future.fromTry(userAnswers.set(ReportForRegisteredBusinessPage, fiDetails.IsFIUser))
-      b <- Future.fromTry(a.set(NameOfFinancialInstitutionPage, fiDetails.FIName))
+      a <- Future.fromTry(userAnswers.set(ReportForRegisteredBusinessPage, fiDetails.IsFIUser, cleanup = false))
+      b <- Future.fromTry(a.set(NameOfFinancialInstitutionPage, fiDetails.FIName, cleanup = false))
       c <- setGIIN(b, fiDetails.TINDetails)
       d <- setAddress(c, fiDetails.AddressDetails)
       e <- setFiUserDetails(d)
@@ -94,12 +94,12 @@ class FinancialInstitutionUpdateService @Inject() (
     tinDetails.find(_.TINType == UTR) match {
       case Some(details) =>
         for {
-          a <- Future.fromTry(userAnswers.set(HaveUniqueTaxpayerReferencePage, true))
-          b <- Future.fromTry(a.set(WhatIsUniqueTaxpayerReferencePage, UniqueTaxpayerReference(details.TIN)))
+          a <- Future.fromTry(userAnswers.set(HaveUniqueTaxpayerReferencePage, true, cleanup = false))
+          b <- Future.fromTry(a.set(WhatIsUniqueTaxpayerReferencePage, UniqueTaxpayerReference(details.TIN), cleanup = false))
         } yield b
       case None =>
         for {
-          a <- Future.fromTry(userAnswers.set(HaveUniqueTaxpayerReferencePage, false))
+          a <- Future.fromTry(userAnswers.set(HaveUniqueTaxpayerReferencePage, false, cleanup = false))
           b <- Future.fromTry(a.remove(WhatIsUniqueTaxpayerReferencePage))
         } yield b
     }
@@ -108,12 +108,12 @@ class FinancialInstitutionUpdateService @Inject() (
     tinDetails.find(_.TINType == GIIN) match {
       case Some(details) =>
         for {
-          a <- Future.fromTry(userAnswers.set(HaveGIINPage, true))
-          b <- Future.fromTry(a.set(WhatIsGIINPage, GIINumber(details.TIN)))
+          a <- Future.fromTry(userAnswers.set(HaveGIINPage, true, cleanup = false))
+          b <- Future.fromTry(a.set(WhatIsGIINPage, GIINumber(details.TIN), cleanup = false))
         } yield b
       case None =>
         for {
-          a <- Future.fromTry(userAnswers.set(HaveGIINPage, false))
+          a <- Future.fromTry(userAnswers.set(HaveGIINPage, false, cleanup = false))
           b <- Future.fromTry(a.remove(WhatIsGIINPage))
         } yield b
     }
@@ -122,9 +122,9 @@ class FinancialInstitutionUpdateService @Inject() (
     val isUkAddress = addressDetails.CountryCode.exists(countryListFactory.countryCodesForUkCountries.contains)
     val addressPage = if (isUkAddress) UkAddressPage else NonUkAddressPage
     for {
-      a <- Future.fromTry(userAnswers.set(WhereIsFIBasedPage, isUkAddress))
+      a <- Future.fromTry(userAnswers.set(WhereIsFIBasedPage, isUkAddress, cleanup = false))
       b <- addressDetails.toAddress(countryListFactory) match {
-        case Some(address) => Future.fromTry(a.set(addressPage, address))
+        case Some(address) => Future.fromTry(a.set(addressPage, address, cleanup = false))
         case None =>
           Future.failed(new RuntimeException(s"Failed to find country with code ${addressDetails.CountryCode}"))
       }
@@ -136,8 +136,8 @@ class FinancialInstitutionUpdateService @Inject() (
     primaryContact map {
       contact =>
         for {
-          a <- Future.fromTry(userAnswers.set(FirstContactNamePage, contact.ContactName))
-          b <- Future.fromTry(a.set(FirstContactEmailPage, contact.EmailAddress))
+          a <- Future.fromTry(userAnswers.set(FirstContactNamePage, contact.ContactName, cleanup = false))
+          b <- Future.fromTry(a.set(FirstContactEmailPage, contact.EmailAddress, cleanup = false))
           c <- setPhoneNumber(b, contact, FirstContactHavePhonePage, FirstContactPhoneNumberPage)
         } yield c
     } getOrElse Future.successful(userAnswers)
@@ -152,31 +152,31 @@ class FinancialInstitutionUpdateService @Inject() (
     contactDetails.PhoneNumber match {
       case Some(phoneNumber) =>
         for {
-          a <- Future.fromTry(userAnswers.set(havePhonePage, true))
-          b <- Future.fromTry(a.set(phoneNumberPage, phoneNumber))
+          a <- Future.fromTry(userAnswers.set(havePhonePage, true, cleanup = false))
+          b <- Future.fromTry(a.set(phoneNumberPage, phoneNumber, cleanup = false))
         } yield b
       case None =>
         for {
-          a <- Future.fromTry(userAnswers.set(havePhonePage, false))
+          a <- Future.fromTry(userAnswers.set(havePhonePage, false, cleanup = false))
           b <- Future.fromTry(a.remove(phoneNumberPage))
         } yield b
     }
 
   private def setFiUserDetails(userAnswers: UserAnswers): Future[UserAnswers] = for {
-    a <- Future.fromTry(userAnswers.set(ReportForRegisteredBusinessPage, true))
-    b <- Future.fromTry(a.set(IsThisYourBusinessNamePage, true))
-    c <- Future.fromTry(b.set(IsThisAddressPage, true))
-    d <- Future.fromTry(c.set(IsTheAddressCorrectPage, true))
+    a <- Future.fromTry(userAnswers.set(ReportForRegisteredBusinessPage, true, cleanup = false))
+    b <- Future.fromTry(a.set(IsThisYourBusinessNamePage, true, cleanup = false))
+    c <- Future.fromTry(b.set(IsThisAddressPage, true, cleanup = false))
+    d <- Future.fromTry(c.set(IsTheAddressCorrectPage, true, cleanup = false))
   } yield d
 
   private def setSecondaryContactDetails(userAnswers: UserAnswers, fiDetails: FIDetail)(implicit ec: ExecutionContext): Future[UserAnswers] =
     for {
-      a <- Future.fromTry(userAnswers.set(SecondContactExistsPage, fiDetails.SecondaryContactDetails.isDefined))
+      a <- Future.fromTry(userAnswers.set(SecondContactExistsPage, fiDetails.SecondaryContactDetails.isDefined, cleanup = false))
       b <- fiDetails.SecondaryContactDetails match {
         case Some(secondaryContact) =>
           for {
-            b <- Future.fromTry(a.set(SecondContactNamePage, secondaryContact.ContactName))
-            c <- Future.fromTry(b.set(SecondContactEmailPage, secondaryContact.EmailAddress))
+            b <- Future.fromTry(a.set(SecondContactNamePage, secondaryContact.ContactName, cleanup = false))
+            c <- Future.fromTry(b.set(SecondContactEmailPage, secondaryContact.EmailAddress, cleanup = false))
             d <- setPhoneNumber(c, secondaryContact, SecondContactCanWePhonePage, SecondContactPhoneNumberPage)
           } yield d
         case None =>

--- a/app/viewmodels/changeFinancialInstitution/FinancialInstitutionIdSummary.scala
+++ b/app/viewmodels/changeFinancialInstitution/FinancialInstitutionIdSummary.scala
@@ -28,7 +28,9 @@ object FinancialInstitutionIdSummary {
     SummaryListRowViewModel(
       key = "financialInstitutionId.changeYourAnswersLabel",
       value = ValueViewModel(HtmlFormat.escape(fiId).toString),
-      actions = Nil
+      actions = Seq(
+        ActionItemViewModel("", "")
+      )
     )
 
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -253,7 +253,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
   implicit class UserAnswersExtension(userAnswers: UserAnswers) {
 
     def withPage[T](page: Settable[T], value: T)(implicit writes: Writes[T]): UserAnswers =
-      userAnswers.set(page, value).success.value
+      userAnswers.set(page, value, cleanup = false).success.value
 
     def removePage[T](page: Settable[T]): UserAnswers = userAnswers.remove(page).success.value
 

--- a/test/controllers/actions/CtUtrRetrievalActionSpec.scala
+++ b/test/controllers/actions/CtUtrRetrievalActionSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers.actions
 
 import base.SpecBase

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import org.scalatest.matchers.must.Matchers
+import pages.addFinancialInstitution.IsRegisteredBusiness.IsThisYourBusinessNamePage
+import pages.addFinancialInstitution.NameOfFinancialInstitutionPage
+
+class UserAnswersSpec extends SpecBase with Matchers {
+
+  "UserAnswers set" - {
+    "should cleanup by default" in {
+      val usersAnswers = emptyUserAnswers
+        .withPage(IsThisYourBusinessNamePage, true)
+        .withPage(NameOfFinancialInstitutionPage, "test")
+      val result = usersAnswers.set(IsThisYourBusinessNamePage, false).get
+      result.data.value must not contain key(NameOfFinancialInstitutionPage.toString)
+    }
+
+    "should not cleanup when cleanup flag is false" in {
+      val usersAnswers = emptyUserAnswers
+        .withPage(IsThisYourBusinessNamePage, true)
+        .withPage(NameOfFinancialInstitutionPage, "test")
+      val result = usersAnswers.set(IsThisYourBusinessNamePage, false, cleanup = false).get
+      result.data.value must contain key NameOfFinancialInstitutionPage.toString
+    }
+  }
+
+}

--- a/test/pages/addFinancialInstitution/AddressPagesSpec.scala
+++ b/test/pages/addFinancialInstitution/AddressPagesSpec.scala
@@ -24,18 +24,24 @@ class AddressPagesSpec extends SpecBase {
 
   "cleanup for" - {
     "UkAddressPage" - {
-      "must remove other address answers from UserAnswers" - {
+      "must remove other address answers from UserAnswers" in {
         val res1: UserAnswers = emptyUserAnswers
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
-          .withPage(UkAddressPage, testAddress)
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
+          .set(UkAddressPage, testAddress)
+          .get
 
         val res2: UserAnswers = emptyUserAnswers
-          .withPage(NonUkAddressPage, testAddress)
-          .withPage(UkAddressPage, testAddress)
+          .set(NonUkAddressPage, testAddress)
+          .get
+          .set(UkAddressPage, testAddress)
+          .get
 
         val res3: UserAnswers = emptyUserAnswers
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
-          .withPage(UkAddressPage, testAddress)
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
+          .set(UkAddressPage, testAddress)
+          .get
 
         res1.get(UkAddressPage) mustBe defined
         res1.data.fields.size mustBe 1
@@ -51,16 +57,22 @@ class AddressPagesSpec extends SpecBase {
     "NonUkAddressPage" - {
       "must remove other address answers from UserAnswers" in {
         val res1: UserAnswers = emptyUserAnswers
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
-          .withPage(NonUkAddressPage, testAddress)
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
+          .set(NonUkAddressPage, testAddress)
+          .get
 
         val res2: UserAnswers = emptyUserAnswers
-          .withPage(UkAddressPage, testAddress)
-          .withPage(NonUkAddressPage, testAddress)
+          .set(UkAddressPage, testAddress)
+          .get
+          .set(NonUkAddressPage, testAddress)
+          .get
 
         val res3: UserAnswers = emptyUserAnswers
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
-          .withPage(NonUkAddressPage, testAddress)
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
+          .set(NonUkAddressPage, testAddress)
+          .get
 
         res1.get(NonUkAddressPage) mustBe defined
         res1.data.fields.size mustBe 1
@@ -76,16 +88,22 @@ class AddressPagesSpec extends SpecBase {
     "SelectedAddressLookupPage" - {
       "must remove other address answers from UserAnswers" in {
         val res1: UserAnswers = emptyUserAnswers
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
 
         val res2: UserAnswers = emptyUserAnswers
-          .withPage(UkAddressPage, testAddress)
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
+          .set(UkAddressPage, testAddress)
+          .get
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
 
         val res3: UserAnswers = emptyUserAnswers
-          .withPage(NonUkAddressPage, testAddress)
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
+          .set(NonUkAddressPage, testAddress)
+          .get
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
 
         res1.get(SelectedAddressLookupPage) mustBe defined
         res1.data.fields.size mustBe 1
@@ -102,16 +120,22 @@ class AddressPagesSpec extends SpecBase {
     "FetchedRegisteredAddressPage" - {
       "must remove other address answers from UserAnswers" in {
         val res1: UserAnswers = emptyUserAnswers
-          .withPage(SelectedAddressLookupPage, testAddressLookup)
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
+          .set(SelectedAddressLookupPage, testAddressLookup)
+          .get
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
 
         val res2: UserAnswers = emptyUserAnswers
-          .withPage(UkAddressPage, testAddress)
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
+          .set(UkAddressPage, testAddress)
+          .get
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
 
         val res3: UserAnswers = emptyUserAnswers
-          .withPage(NonUkAddressPage, testAddress)
-          .withPage(FetchedRegisteredAddressPage, testAddressResponse)
+          .set(NonUkAddressPage, testAddress)
+          .get
+          .set(FetchedRegisteredAddressPage, testAddressResponse)
+          .get
 
         res1.get(FetchedRegisteredAddressPage) mustBe defined
         res1.data.fields.size mustBe 1


### PR DESCRIPTION
Updated the UserAnswers `set` method to include an optional cleanup flag, allowing control over the cleanup behavior. Modified all existing `set` calls to pass the cleanup flag where necessary and added relevant test cases to verify the new functionality.