### PR TITLE
DAC6-3293: Update GIIN processing

### DIFF
--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
@@ -66,7 +66,7 @@ class IsTheAddressCorrectController @Inject() (
               address =>
                 for {
                   addressWithCountry <- Future.fromTry(addCountryToAddress(address))
-                  updatedAnswers     <- Future.fromTry(request.userAnswers.set(FetchedRegisteredAddressPage, addressWithCountry))
+                  updatedAnswers     <- Future.fromTry(request.userAnswers.set(FetchedRegisteredAddressPage, addressWithCountry, cleanup = false))
                   result <- sessionRepository.set(updatedAnswers).map {
                     _ =>
                       val preparedForm = request.userAnswers.get(IsTheAddressCorrectPage) match {

--- a/app/services/FinancialInstitutionsService.scala
+++ b/app/services/FinancialInstitutionsService.scala
@@ -17,7 +17,7 @@
 package services
 
 import connectors.FinancialInstitutionsConnector
-import models.FinancialInstitutions.TINType.UTR
+import models.FinancialInstitutions.TINType.{GIIN, UTR}
 import models.FinancialInstitutions._
 import models.UserAnswers
 import pages.addFinancialInstitution.IsRegisteredBusiness.{FetchedRegisteredAddressPage, ReportForRegisteredBusinessPage}
@@ -106,7 +106,7 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
     }
 
     val giin = userAnswers.get(WhatIsGIINPage) match {
-      case Some(giin) => Seq(TINDetails(UTR, giin.value, "US"))
+      case Some(giin) => Seq(TINDetails(GIIN, giin.value, "US"))
       case _          => Seq.empty
     }
 

--- a/app/viewmodels/common/package.scala
+++ b/app/viewmodels/common/package.scala
@@ -76,7 +76,7 @@ package object common {
     val fetchedAddress = FetchedRegisteredAddressSummary.row(ua, pageType)
 
     (addressLookup.isDefined, nonUkAddress.isDefined, ukAddress.isDefined, fetchedAddress.isDefined) match {
-      case (false, false, true, false) => ukAddress
+      case (false, false, true, _)     => ukAddress
       case (false, true, false, false) => nonUkAddress
       case (true, false, false, _)     => addressLookup
       case (_, _, _, true)             => fetchedAddress

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -370,8 +370,8 @@ changeYourAnswers.p1 = Back to manage your financial institutions
 changeYourAnswers.changed.p2 = By changing these details, you are confirming that the information is correct and complete to the best of your knowledge.
 changeYourAnswers.submit.button = Confirm and send
 
-changeYourRegisteredAnswers.title = Change the details for the financial institution
-changedYourRegisteredAnswers.title = Check the details for the financial institution
+changeYourRegisteredAnswers.title = Change the details for the registered business
+changedYourRegisteredAnswers.title = Check the details for the registered business
 changeYourRegisteredAnswers.heading = Change the details for {0}
 changedYourRegisteredAnswers.heading = Check the details for {0}
 changeYourRegisteredAnswers.changed.subheading = Now send these details for the registered business


### PR DESCRIPTION
Changed TIN type from UTR to GIIN in `FinancialInstitutionsService` for correct GIIN processing. Also updated message titles to refer to "registered business" instead of "financial institution".