### PR TITLE
DAC6-3361: Add service to clear UserAnswers

### DIFF
--- a/app/controllers/YourFinancialInstitutionsController.scala
+++ b/app/controllers/YourFinancialInstitutionsController.scala
@@ -23,7 +23,7 @@ import pages.{RemoveAreYouSurePage, RemoveInstitutionDetail}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
-import services.FinancialInstitutionsService
+import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.govuk.all.SummaryListViewModel
 import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows
@@ -40,6 +40,7 @@ class YourFinancialInstitutionsController @Inject() (
   requireData: DataRequiredAction,
   formProvider: YourFinancialInstitutionsFormProvider,
   val controllerComponents: MessagesControllerComponents,
+  val financialInstitutionUpdateService: FinancialInstitutionUpdateService,
   val financialInstitutionsService: FinancialInstitutionsService,
   view: YourFinancialInstitutionsView
 )(implicit ec: ExecutionContext)
@@ -83,7 +84,12 @@ class YourFinancialInstitutionsController @Inject() (
               institutions => Ok(view(formWithErrors, SummaryListViewModel(getYourFinancialInstitutionsRows(institutions))))
             },
           {
-            case true  => Future.successful(Redirect(controllers.addFinancialInstitution.routes.AddFIController.onPageLoad))
+            case true =>
+              financialInstitutionUpdateService
+                .clearUserAnswers(request.userAnswers)
+                .flatMap(
+                  _ => Future.successful(Redirect(controllers.addFinancialInstitution.routes.AddFIController.onPageLoad))
+                )
             case false => Future.successful(Redirect(controllers.routes.IndexController.onPageLoad()))
           }
         )

--- a/test/controllers/YourFinancialInstitutionsControllerSpec.scala
+++ b/test/controllers/YourFinancialInstitutionsControllerSpec.scala
@@ -18,13 +18,14 @@ package controllers
 
 import base.SpecBase
 import forms.addFinancialInstitution.YourFinancialInstitutionsFormProvider
+import models.UserAnswers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.FinancialInstitutionsService
+import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
 import uk.gov.hmrc.http.HeaderCarrier
 import viewmodels.govuk.all.SummaryListViewModel
 import views.html.YourFinancialInstitutionsView
@@ -64,7 +65,13 @@ class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar
 
     "must redirect to Add new FI when user selects yes" in {
 
-      val application = applicationBuilder(userAnswers = Option(emptyUserAnswers)).build()
+      val mockFinancialInstitutionUpdateService = mock[FinancialInstitutionUpdateService]
+      when(mockFinancialInstitutionUpdateService.clearUserAnswers(any[UserAnswers])).thenReturn(Future.successful(true))
+      val application = applicationBuilder(userAnswers = Option(emptyUserAnswers))
+        .overrides(
+          bind[FinancialInstitutionUpdateService].toInstance(mockFinancialInstitutionUpdateService)
+        )
+        .build()
 
       running(application) {
         val request =
@@ -74,6 +81,7 @@ class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual controllers.addFinancialInstitution.routes.AddFIController.onPageLoad.url
+        verify(mockFinancialInstitutionUpdateService).clearUserAnswers(any[UserAnswers])
       }
     }
 


### PR DESCRIPTION
Integrated FinancialInstitutionUpdateService to clear user answers before redirecting when user selects 'yes'. This ensures that stale data is not carried forward during financial institution updates.