### PR TITLE
DAC6-3361: Remove PostcodePage references

### DIFF
--- a/app/utils/CheckYourAnswersValidator.scala
+++ b/app/utils/CheckYourAnswersValidator.scala
@@ -58,7 +58,6 @@ sealed trait AddFIValidator {
   private[utils] def checkAddressMissingAnswers: Seq[Page] = (userAnswers.get(WhereIsFIBasedPage) match {
     case Some(true) =>
       any(
-        checkPage(PostcodePage),
         checkPage(SelectedAddressLookupPage),
         checkPage(UkAddressPage),
         checkPage(IsThisAddressPage)

--- a/test/controllers/changeFinancialInstitution/ChangeFinancialInstitutionControllerSpec.scala
+++ b/test/controllers/changeFinancialInstitution/ChangeFinancialInstitutionControllerSpec.scala
@@ -24,23 +24,11 @@ import models.{RequestType, UserAnswers}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito.when
-import org.mockito.MockitoSugar.{reset, times, verify}
+import org.mockito.MockitoSugar.reset
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.mockito.MockitoSugar.mock
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import pages.addFinancialInstitution.{
-  FirstContactEmailPage,
-  FirstContactHavePhonePage,
-  FirstContactNamePage,
-  HaveGIINPage,
-  HaveUniqueTaxpayerReferencePage,
-  IsThisAddressPage,
-  NameOfFinancialInstitutionPage,
-  SecondContactExistsPage,
-  SelectedAddressLookupPage,
-  WhereIsFIBasedPage
-}
+import pages.addFinancialInstitution._
 import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.http.Status.INTERNAL_SERVER_ERROR
 import play.api.inject.bind

--- a/test/utils/CheckYourAnswersValidatorSpec.scala
+++ b/test/utils/CheckYourAnswersValidatorSpec.scala
@@ -52,7 +52,6 @@ class CheckYourAnswersValidatorSpec extends AnyFreeSpec with Matchers with Model
               HaveGIINPage,
               HaveUniqueTaxpayerReferencePage,
               IsThisAddressPage,
-              PostcodePage,
               SelectAddressPage,
               SelectedAddressLookupPage,
               NonUkAddressPage,


### PR DESCRIPTION
Eliminate all occurrences of PostcodePage from CheckYourAnswersValidator and associated test files. This reduces redundancy and cleans up the codebase by removing an unnecessary page check.