### PR TITLE
DAC6-3413: Add exclusive checkbox logic

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -14,6 +14,25 @@ document.addEventListener('DOMContentLoaded', function(event) {
       window.history.back();
     });
   }
+
+  // handle exclusive checkbox
+  var checkboxes = document.querySelectorAll('.govuk-checkboxes__input');
+  var exclusiveCheckbox = document.querySelector('[data-behaviour="exclusive"]');
+  if (exclusiveCheckbox !== null) {
+    checkboxes.forEach(function (checkbox) {
+      checkbox.addEventListener('click', function() {
+        if (checkbox === exclusiveCheckbox) {
+          checkboxes.forEach(function (c) {
+            if (c !== exclusiveCheckbox) {
+              c.checked = false;
+            }
+          });
+        } else {
+          exclusiveCheckbox.checked = false;
+        }
+      });
+    });
+  }
 });
 
 // This fixes error styling on accessible autocomplete for country selection

--- a/app/models/WhichIdentificationNumbers.scala
+++ b/app/models/WhichIdentificationNumbers.scala
@@ -37,6 +37,13 @@ object WhichIdentificationNumbers extends Enumerable.Implicits {
 
   def checkboxItems(implicit messages: Messages): Seq[CheckboxItem] = {
     val items = values.zipWithIndex.map {
+      case (TRN, index) =>
+        CheckboxItemViewModel(
+          content = Text(messages(s"whichIdentificationNumbers.${TRN.toString}")),
+          fieldId = "value",
+          index = index,
+          value = TRN.toString
+        ).withAttribute(("data-behaviour", "exclusive"))
       case (value, index) =>
         CheckboxItemViewModel(
           content = Text(messages(s"whichIdentificationNumbers.${value.toString}")),

--- a/test/controllers/NotInUKControllerSpec.scala
+++ b/test/controllers/NotInUKControllerSpec.scala
@@ -18,7 +18,6 @@ package controllers
 
 import base.SpecBase
 import models.UserAnswers
-import pages.RemoveInstitutionDetail
 import pages.addFinancialInstitution.NameOfFinancialInstitutionPage
 import play.api.test.FakeRequest
 import play.api.test.Helpers._


### PR DESCRIPTION
Introduced functionality to handle exclusive behavior for specific checkboxes in both Scala and JavaScript. Updated `WhichIdentificationNumbers` to include exclusive attributes and added JavaScript logic to ensure proper interaction between exclusive and non-exclusive checkboxes. Removed unused import from `NotInUKControllerSpec`.