### PR TITLE
DAC6-3471: Update subscription model structure

### DIFF
--- a/app/models/subscription/response/DisplaySubscriptionResponse.scala
+++ b/app/models/subscription/response/DisplaySubscriptionResponse.scala
@@ -18,7 +18,7 @@ package models.subscription.response
 
 import play.api.libs.json.{Json, OFormat}
 
-case class DisplaySubscriptionResponse(success: UserSubscription)
+case class DisplaySubscriptionResponse(success: CrfaSubscriptionDetails)
 
 object DisplaySubscriptionResponse {
   implicit lazy val format: OFormat[DisplaySubscriptionResponse] = Json.format[DisplaySubscriptionResponse]

--- a/app/models/subscription/response/UserSubscription.scala
+++ b/app/models/subscription/response/UserSubscription.scala
@@ -19,8 +19,14 @@ package models.subscription.response
 import models.subscription.request.{ContactInformation, OrganisationDetails}
 import play.api.libs.json.{Json, OFormat}
 
+case class CrfaSubscriptionDetails(crfaSubscriptionDetails: UserSubscription)
+
+object CrfaSubscriptionDetails {
+  implicit lazy val format: OFormat[CrfaSubscriptionDetails] = Json.format[CrfaSubscriptionDetails]
+}
+
 case class UserSubscription(
-  id: String,
+  crfaReference: String,
   tradingName: Option[String],
   gbUser: Boolean,
   primaryContact: ContactInformation,

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -29,6 +29,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class SubscriptionService @Inject() (val subscriptionConnector: SubscriptionConnector) extends Logging {
 
   def getSubscription(fatcaId: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[UserSubscription] =
-    subscriptionConnector.readSubscription(ReadSubscriptionRequest(IdentifierType.FATCAID, fatcaId)).map(_.success)
+    subscriptionConnector.readSubscription(ReadSubscriptionRequest(IdentifierType.FATCAID, fatcaId)).map(_.success.crfaSubscriptionDetails)
 
 }

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -45,18 +45,20 @@ class SubscriptionConnectorSpec extends SpecBase with WireMockServerHandler with
 
   val exampleResponse = s"""{
     "success": {
-      "processingDate": "2023-05-17T09:26:17Z",
-      "id": "[subscriptionId]",
-      "tradingName": "James Hank",
-      "gbUser": true,
-      "primaryContact": {
-      "organisation": {
-      "name": "Mark Ltd"
-    },
-      "email": "james@test.com",
-      "phone": "0202731454",
-      "mobile": "07896543333"
-    }
+    "crfaSubscriptionDetails": {
+        "processingDate": "2023-05-17T09:26:17Z",
+        "crfaReference": "[subscriptionId]",
+        "tradingName": "James Hank",
+        "gbUser": true,
+        "primaryContact": {
+        "organisation": {
+        "name": "Mark Ltd"
+      },
+        "email": "james@test.com",
+        "phone": "0202731454",
+        "mobile": "07896543333"
+      }
+      }
     }
   }""".stripMargin
 


### PR DESCRIPTION
Refactor `UserSubscription` to nest within `CrfaSubscriptionDetails` for better alignment with API response. Adjust related models and services to accommodate the updated structure.