### PR TITLE
DAC6-3447: Simplify address logic

### DIFF
--- a/app/viewmodels/common/package.scala
+++ b/app/viewmodels/common/package.scala
@@ -89,7 +89,7 @@ package object common {
     val fetchedAddress = FetchedRegisteredAddressSummary.row(ua, pageType)
 
     (addressLookup.isDefined, nonUkAddress.isDefined, ukAddress.isDefined, fetchedAddress.isDefined) match {
-      case (false, false, true, _)     => ukAddress
+      case (_, false, true, _)         => ukAddress
       case (false, true, false, false) => nonUkAddress
       case (true, false, false, _)     => addressLookup
       case (_, _, _, true)             => fetchedAddress


### PR DESCRIPTION
Updated pattern matching to remove unnecessary strictness for `addressLookup` in UK address condition. This ensures more robust and maintainable logic for determining address types.