### PR TITLE
DAC6-3432: handle missing fiName with default text

### DIFF
--- a/app/controllers/DetailsUpdatedController.scala
+++ b/app/controllers/DetailsUpdatedController.scala
@@ -40,8 +40,7 @@ class DetailsUpdatedController @Inject() (
 
   def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-      val x: Option[String] = request.flash.get("fiName")
-      Ok(view(x))
+      Ok(view(request.flash.get("fiName")))
   }
 
 }

--- a/app/controllers/DetailsUpdatedController.scala
+++ b/app/controllers/DetailsUpdatedController.scala
@@ -40,11 +40,8 @@ class DetailsUpdatedController @Inject() (
 
   def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>
-      request.flash.get("fiName") match {
-        case Some(fiName) => Ok(view(fiName)) // Render the view with fiName
-        case _            => Ok(view("")) // Handle missing fiName
-      }
-
+      val x: Option[String] = request.flash.get("fiName")
+      Ok(view(x))
   }
 
 }

--- a/app/views/DetailsUpdatedView.scala.html
+++ b/app/views/DetailsUpdatedView.scala.html
@@ -26,12 +26,14 @@
     link: Link
 )
 
-@(fiName: String)(implicit request: Request[_], messages: Messages)
+@(fiName: Option[String])(implicit request: Request[_], messages: Messages)
+
+@fi = @{fiName.getOrElse(messages("detailsUpdated.default.fi"))}
 
 @layout(pageTitle = titleNoForm(messages("detailsUpdated.title")), showBackLink = false) {
     @govukPanel(
         Panel(
-            title = Text(messages("detailsUpdated.heading", fiName))
+            title = Text(messages("detailsUpdated.heading", fi))
         )
     )
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -412,6 +412,7 @@ detailsUpdated.title = Details updated
 detailsUpdated.heading = Details updated for {0}
 detailsUpdated.p1 = Back to manage your financial institutions
 detailsUpdated.p2 = Back to manage your CRS and FATCA reports
+detailsUpdated.default.fi = the financial institution
 
 trustURN.title = What is the trust Unique Reference Number (URN) for the financial institution?
 trustURN.heading = What is the trust Unique Reference Number (URN) for {0}?

--- a/test/controllers/DetailsUpdatedControllerSpec.scala
+++ b/test/controllers/DetailsUpdatedControllerSpec.scala
@@ -37,7 +37,7 @@ class DetailsUpdatedControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[DetailsUpdatedView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(fiName)(request, messages(application)).toString
+        contentAsString(result) mustEqual view(Some(fiName))(request, messages(application)).toString
       }
     }
   }


### PR DESCRIPTION
Because we are using flash storage to carry the financial institution name safely to the /details-updated page (after useranswers are cleared)- once the user moves away this will be lost and so ive added the default 'the financial institution' in place of missing data should the user redirect and return to this page.