### PR TITLE
DAC6-3458: Normalize postcode comparison

### DIFF
--- a/app/models/Address.scala
+++ b/app/models/Address.scala
@@ -50,7 +50,7 @@ case class Address(
       this.addressLine2 == that.addressLine2 &&
       this.addressLine3 == that.addressLine3 &&
       this.addressLine4 == that.addressLine4 &&
-      this.postCode == that.postCode &&
+      this.postCode.map(_.trim.replaceAll(" ", "")) == that.postCode.map(_.trim.replaceAll(" ", "")) &&
       this.country.code == that.country.code
     case _ => false
   }


### PR DESCRIPTION
Ensure postcodes are trimmed and spaces are removed before comparison. This avoids mismatches caused by formatting differences.