### PR TITLE
DAC6-3417: Add ChangeUserAnswersRepository

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -60,7 +60,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   val timeout: Int   = configuration.get[Int]("timeout-dialog.timeout")
   val countdown: Int = configuration.get[Int]("timeout-dialog.countdown")
 
-  val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  val cacheTtl: Int              = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  val changeAnswersCacheTtl: Int = configuration.get[Int]("mongodb.changeAnswersTimeToLiveInSeconds")
 
   val enrolmentKey: String   = configuration.get[String]("keys.enrolmentKey.crsFatca")
   val ctEnrolmentKey: String = configuration.get[String]("keys.enrolmentKey.ct")

--- a/app/controllers/addFinancialInstitution/FirstContactEmailController.scala
+++ b/app/controllers/addFinancialInstitution/FirstContactEmailController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution.FirstContactEmailFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{FirstContactEmailPage, FirstContactNamePage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.FirstContactEmailView
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FirstContactEmailController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -83,6 +85,7 @@ class FirstContactEmailController @Inject() (
                   for {
                     updatedAnswers <- Future.fromTry(ua.set(FirstContactEmailPage, value))
                     _              <- sessionRepository.set(updatedAnswers)
+                    _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
                   } yield Redirect(navigator.nextPage(FirstContactEmailPage, mode, updatedAnswers))
               )
         }

--- a/app/controllers/addFinancialInstitution/FirstContactHavePhoneController.scala
+++ b/app/controllers/addFinancialInstitution/FirstContactHavePhoneController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution._
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{FirstContactHavePhonePage, FirstContactNamePage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.FirstContactHavePhoneView
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FirstContactHavePhoneController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -78,6 +80,7 @@ class FirstContactHavePhoneController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(ua.set(FirstContactHavePhonePage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(FirstContactHavePhonePage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/FirstContactNameController.scala
+++ b/app/controllers/addFinancialInstitution/FirstContactNameController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.FirstContactNameFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.FirstContactNamePage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.FirstContactNameView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FirstContactNameController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -72,6 +74,7 @@ class FirstContactNameController @Inject() (
                 request.userAnswers.set(FirstContactNamePage, value)
               )
               _ <- sessionRepository.set(updatedAnswers)
+              _ <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
 
             } yield Redirect(navigator.nextPage(FirstContactNamePage, mode, updatedAnswers))
         )

--- a/app/controllers/addFinancialInstitution/FirstContactPhoneNumberController.scala
+++ b/app/controllers/addFinancialInstitution/FirstContactPhoneNumberController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.FirstContactPhoneNumberFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.FirstContactPhoneNumberPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.FirstContactPhoneNumberView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class FirstContactPhoneNumberController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -68,6 +70,7 @@ class FirstContactPhoneNumberController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(FirstContactPhoneNumberPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(FirstContactPhoneNumberPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/HaveGIINController.scala
+++ b/app/controllers/addFinancialInstitution/HaveGIINController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.HaveGIINFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.HaveGIINPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.HaveGIINView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class HaveGIINController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -68,6 +70,7 @@ class HaveGIINController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(HaveGIINPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(HaveGIINPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/HaveUniqueTaxpayerReferenceController.scala
+++ b/app/controllers/addFinancialInstitution/HaveUniqueTaxpayerReferenceController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.HaveUniqueTaxpayerReferenceFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.HaveUniqueTaxpayerReferencePage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.HaveUniqueTaxpayerReferenceView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class HaveUniqueTaxpayerReferenceController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -68,6 +70,7 @@ class HaveUniqueTaxpayerReferenceController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(HaveUniqueTaxpayerReferencePage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(HaveUniqueTaxpayerReferencePage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/IsThisAddressController.scala
+++ b/app/controllers/addFinancialInstitution/IsThisAddressController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.IsThisAddressFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{AddressLookupPage, IsThisAddressPage, SelectedAddressLookupPage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.IsThisAddressView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class IsThisAddressController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -78,6 +80,8 @@ class IsThisAddressController @Inject() (
                   updatedAnswers                    <- Future.fromTry(ua.set(IsThisAddressPage, value))
                   updatedAnswersWithSelectedAddress <- Future.fromTry(updatedAnswers.set(SelectedAddressLookupPage, address.head))
                   _                                 <- sessionRepository.set(updatedAnswersWithSelectedAddress)
+                  _ <- changeUserAnswersRepository
+                    .set(request.fatcaId, updatedAnswersWithSelectedAddress.get(ChangeFiDetailsInProgressId), updatedAnswersWithSelectedAddress)
                 } yield Redirect(navigator.nextPage(IsThisAddressPage, mode, updatedAnswersWithSelectedAddress))
             )
         case None => Future.successful(Redirect(controllers.routes.JourneyRecoveryController.onPageLoad()))

--- a/app/controllers/addFinancialInstitution/NameOfFinancialInstitutionController.scala
+++ b/app/controllers/addFinancialInstitution/NameOfFinancialInstitutionController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution.NameOfFinancialInstitutionFormProvider
 import models.{Mode, UserAnswers}
 import navigation.Navigator
 import pages.addFinancialInstitution.NameOfFinancialInstitutionPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.addFinancialInstitution.NameOfFinancialInstitutionView
 
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class NameOfFinancialInstitutionController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -81,6 +83,7 @@ class NameOfFinancialInstitutionController @Inject() (
                   .set(NameOfFinancialInstitutionPage, value)
               )
               _ <- sessionRepository.set(updatedAnswers)
+              _ <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(NameOfFinancialInstitutionPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/PostcodeController.scala
+++ b/app/controllers/addFinancialInstitution/PostcodeController.scala
@@ -22,10 +22,11 @@ import forms.addFinancialInstitution.PostcodeFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{AddressLookupPage, PostcodePage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.FormError
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.PostcodeView
@@ -36,6 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class PostcodeController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -79,6 +81,7 @@ class PostcodeController @Inject() (
                   updatedAnswers            <- Future.fromTry(request.userAnswers.set(PostcodePage, postCode))
                   updatedAnswersWithAddress <- Future.fromTry(updatedAnswers.set(AddressLookupPage, addresses))
                   _                         <- sessionRepository.set(updatedAnswersWithAddress)
+                  _                         <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
                 } yield Redirect(navigator.nextPage(PostcodePage, mode, updatedAnswersWithAddress))
             }
         )

--- a/app/controllers/addFinancialInstitution/SecondContactCanWePhoneController.scala
+++ b/app/controllers/addFinancialInstitution/SecondContactCanWePhoneController.scala
@@ -22,10 +22,11 @@ import models.Mode
 import models.requests.DataRequest
 import navigation.Navigator
 import pages.addFinancialInstitution.{NameOfFinancialInstitutionPage, SecondContactCanWePhonePage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.SecondContactCanWePhoneView
@@ -36,6 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecondContactCanWePhoneController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -78,6 +80,7 @@ class SecondContactCanWePhoneController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(SecondContactCanWePhonePage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(SecondContactCanWePhonePage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/SecondContactEmailController.scala
+++ b/app/controllers/addFinancialInstitution/SecondContactEmailController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution.SecondContactEmailFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{SecondContactEmailPage, SecondContactNamePage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.SecondContactEmailView
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecondContactEmailController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -83,6 +85,7 @@ class SecondContactEmailController @Inject() (
                   for {
                     updatedAnswers <- Future.fromTry(ua.set(SecondContactEmailPage, value))
                     _              <- sessionRepository.set(updatedAnswers)
+                    _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
                   } yield Redirect(navigator.nextPage(SecondContactEmailPage, mode, updatedAnswers))
               )
         }

--- a/app/controllers/addFinancialInstitution/SecondContactExistsController.scala
+++ b/app/controllers/addFinancialInstitution/SecondContactExistsController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.SecondContactExistsFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.SecondContactExistsPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.SecondContactExistsView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecondContactExistsController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -68,6 +70,7 @@ class SecondContactExistsController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(SecondContactExistsPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(SecondContactExistsPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/SecondContactNameController.scala
+++ b/app/controllers/addFinancialInstitution/SecondContactNameController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.SecondContactNameFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.SecondContactNamePage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.SecondContactNameView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecondContactNameController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -69,6 +71,7 @@ class SecondContactNameController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(SecondContactNamePage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(SecondContactNamePage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/SecondContactPhoneNumberController.scala
+++ b/app/controllers/addFinancialInstitution/SecondContactPhoneNumberController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.SecondContactPhoneNumberFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{SecondContactNamePage, SecondContactPhoneNumberPage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.addFinancialInstitution.SecondContactPhoneNumberView
 
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SecondContactPhoneNumberController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -69,6 +71,7 @@ class SecondContactPhoneNumberController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(SecondContactPhoneNumberPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(SecondContactPhoneNumberPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/SelectAddressController.scala
+++ b/app/controllers/addFinancialInstitution/SelectAddressController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution.SelectAddressFormProvider
 import models.{AddressLookup, Mode}
 import navigation.Navigator
 import pages.addFinancialInstitution.{AddressLookupPage, SelectAddressPage, SelectedAddressLookupPage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -38,6 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class SelectAddressController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -91,6 +93,8 @@ class SelectAddressController @Inject() (
                     request.userAnswers.set(SelectedAddressLookupPage, addressToStore).flatMap(_.remove(AddressLookupPage))
                   )
                   _ <- sessionRepository.set(updatedAnswersWithSelectedAddress)
+                  _ <- changeUserAnswersRepository
+                    .set(request.fatcaId, updatedAnswersWithSelectedAddress.get(ChangeFiDetailsInProgressId), updatedAnswersWithSelectedAddress)
                 } yield Redirect(navigator.nextPage(SelectAddressPage, mode, updatedAnswersWithSelectedAddress))
               }
             )

--- a/app/controllers/addFinancialInstitution/TrustURNController.scala
+++ b/app/controllers/addFinancialInstitution/TrustURNController.scala
@@ -21,9 +21,10 @@ import forms.TrustURNFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.TrustURNPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.TrustURNView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class TrustURNController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -70,6 +72,7 @@ class TrustURNController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(TrustURNPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(TrustURNPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/UkAddressController.scala
+++ b/app/controllers/addFinancialInstitution/UkAddressController.scala
@@ -21,10 +21,11 @@ import forms.addFinancialInstitution.UkAddressFormProvider
 import models.{Country, Mode}
 import navigation.Navigator
 import pages.addFinancialInstitution.UkAddressPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.{ContactHelper, CountryListFactory}
 import views.html.addFinancialInstitution.UkAddressView
@@ -36,6 +37,7 @@ class UkAddressController @Inject() (
   override val messagesApi: MessagesApi,
   countryListFactory: CountryListFactory,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -88,6 +90,7 @@ class UkAddressController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(UkAddressPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(UkAddressPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/WhatIsCompanyRegistrationNumberController.scala
+++ b/app/controllers/addFinancialInstitution/WhatIsCompanyRegistrationNumberController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.CompanyRegistrationNumberFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.CompanyRegistrationNumberPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.WhatIsCompanyRegistrationNumberView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class WhatIsCompanyRegistrationNumberController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   formProvider: CompanyRegistrationNumberFormProvider,
   identify: IdentifierAction,
@@ -70,6 +72,7 @@ class WhatIsCompanyRegistrationNumberController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(CompanyRegistrationNumberPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(CompanyRegistrationNumberPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/WhatIsGIINController.scala
+++ b/app/controllers/addFinancialInstitution/WhatIsGIINController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.WhatIsGIINFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.{HaveGIINPage, WhatIsGIINPage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.WhatIsGIINView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class WhatIsGIINController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -77,6 +79,7 @@ class WhatIsGIINController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsGIINPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(WhatIsGIINPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/WhatIsUniqueTaxpayerReferenceController.scala
+++ b/app/controllers/addFinancialInstitution/WhatIsUniqueTaxpayerReferenceController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.WhatIsUniqueTaxpayerReferenceFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.WhatIsUniqueTaxpayerReferencePage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.WhatIsUniqueTaxpayerReferenceView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class WhatIsUniqueTaxpayerReferenceController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -69,6 +71,7 @@ class WhatIsUniqueTaxpayerReferenceController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(WhatIsUniqueTaxpayerReferencePage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(WhatIsUniqueTaxpayerReferencePage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/WhichIdentificationNumbersController.scala
+++ b/app/controllers/addFinancialInstitution/WhichIdentificationNumbersController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.WhichIdentificationNumbersFormProvider
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.WhichIdentificationNumbersPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.addFinancialInstitution.WhichIdentificationNumbersView
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class WhichIdentificationNumbersController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -69,6 +71,7 @@ class WhichIdentificationNumbersController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(WhichIdentificationNumbersPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(WhichIdentificationNumbersPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsTheAddressCorrectController.scala
@@ -22,10 +22,11 @@ import forms.addFinancialInstitution.IsRegisteredBusiness.IsTheAddressCorrectFor
 import models.{AddressResponse, Country, Mode}
 import navigation.Navigator
 import pages.addFinancialInstitution.IsRegisteredBusiness.{FetchedRegisteredAddressPage, IsTheAddressCorrectPage}
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import services.RegistrationWithUtrService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.{ContactHelper, CountryListFactory}
@@ -38,6 +39,7 @@ import scala.util.{Failure, Success, Try}
 class IsTheAddressCorrectController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -120,6 +122,7 @@ class IsTheAddressCorrectController @Inject() (
                   for {
                     updatedAnswers <- Future.fromTry(request.userAnswers.set(IsTheAddressCorrectPage, value))
                     _              <- sessionRepository.set(updatedAnswers)
+                    _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
                   } yield (address.countryCode, value) match {
                     case (country, true) if country != Country.GB.code =>
                       Redirect(controllers.routes.NotInUKController.onPageLoad())

--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsThisYourBusinessNameController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsThisYourBusinessNameController.scala
@@ -23,10 +23,11 @@ import models.{Mode, UserAnswers}
 import navigation.Navigator
 import pages.addFinancialInstitution.IsRegisteredBusiness.IsThisYourBusinessNamePage
 import pages.addFinancialInstitution.NameOfFinancialInstitutionPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import services.SubscriptionService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.addFinancialInstitution.IsRegisteredBusiness.IsThisYourBusinessNameView
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class IsThisYourBusinessNameController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -90,6 +92,7 @@ class IsThisYourBusinessNameController @Inject() (
                       updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisYourBusinessNamePage, value))
                       updatedFIName  <- setFIName(value, fiName, updatedAnswers)
                       _              <- sessionRepository.set(updatedFIName)
+                      _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
                     } yield Redirect(navigator.nextPage(IsThisYourBusinessNamePage, mode, updatedAnswers))
                 )
           }

--- a/app/controllers/addFinancialInstitution/registeredBusiness/ReportForRegisteredBusinessController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/ReportForRegisteredBusinessController.scala
@@ -21,9 +21,10 @@ import forms.addFinancialInstitution.IsRegisteredBusiness.ReportForRegisteredBus
 import models.Mode
 import navigation.Navigator
 import pages.addFinancialInstitution.IsRegisteredBusiness.ReportForRegisteredBusinessPage
+import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.addFinancialInstitution.IsRegisteredBusiness.ReportForRegisteredBusinessView
 
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class ReportForRegisteredBusinessController @Inject() (
   override val messagesApi: MessagesApi,
   sessionRepository: SessionRepository,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   navigator: Navigator,
   identify: IdentifierAction,
   getData: DataRetrievalAction,
@@ -66,6 +68,7 @@ class ReportForRegisteredBusinessController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(ReportForRegisteredBusinessPage, value))
               _              <- sessionRepository.set(updatedAnswers)
+              _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
             } yield Redirect(navigator.nextPage(ReportForRegisteredBusinessPage, mode, updatedAnswers))
         )
   }

--- a/app/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionController.scala
+++ b/app/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionController.scala
@@ -26,6 +26,7 @@ import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import repositories.ChangeUserAnswersRepository
 import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.{CheckYourAnswersValidator, ContactHelper}
@@ -41,6 +42,7 @@ class ChangeRegisteredFinancialInstitutionController @Inject() (
   identify: IdentifierAction,
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
+  changeUserAnswersRepository: ChangeUserAnswersRepository,
   financialInstitutionsService: FinancialInstitutionsService,
   financialInstitutionUpdateService: FinancialInstitutionUpdateService,
   val controllerComponents: MessagesControllerComponents,
@@ -69,9 +71,10 @@ class ChangeRegisteredFinancialInstitutionController @Inject() (
                     Future.successful(Redirect(routes.SomeInformationMissingController.onPageLoad()))
                 }
               case _ =>
+                val hasChanges = financialInstitutionUpdateService.registeredFiDetailsHasChanged(userAnswers, fiDetails)
                 financialInstitutionUpdateService
                   .populateAndSaveRegisteredFiDetails(userAnswers, fiDetails)
-                  .map(createPage(fiid, _, hasChanges = false))
+                  .map(createPage(fiid, _, hasChanges = hasChanges))
                   .recoverWith {
                     exception =>
                       logger.error(s"Failed to populate and save FI details to user answers for subscription Id: [${request.fatcaId}] and FI Id [$fiid]",
@@ -98,6 +101,9 @@ class ChangeRegisteredFinancialInstitutionController @Inject() (
         .updateFinancialInstitution(request.fatcaId, request.userAnswers)
         .flatMap(
           _ => financialInstitutionUpdateService.clearUserAnswers(request.userAnswers)
+        )
+        .flatMap(
+          _ => changeUserAnswersRepository.clear(request.userId, request.userAnswers.get(ChangeFiDetailsInProgressId))
         )
         .map(
           _ => Redirect(controllers.routes.DetailsUpdatedController.onPageLoad()).flashing("fiName" -> fiName)

--- a/app/repositories/ChangeUserAnswersRepository.scala
+++ b/app/repositories/ChangeUserAnswersRepository.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.FrontendAppConfig
+import models.CryptoType.CryptoT
+import models.UserAnswers
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model._
+import play.api.libs.json.Format
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.{Clock, Instant}
+import java.util.concurrent.TimeUnit
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ChangeUserAnswersRepository @Inject() (
+  mongoComponent: MongoComponent,
+  appConfig: FrontendAppConfig,
+  clock: Clock
+)(implicit ec: ExecutionContext, crypto: CryptoT)
+    extends PlayMongoRepository[UserAnswers](
+      collectionName = "change-user-answers",
+      mongoComponent = mongoComponent,
+      domainFormat = UserAnswers.mongoFormat(appConfig.encryptionEnabled),
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("lastUpdated"),
+          IndexOptions()
+            .name("changeLastUpdatedIdx")
+            .expireAfter(appConfig.changeAnswersCacheTtl, TimeUnit.SECONDS)
+        )
+      )
+    ) {
+
+  implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  private def byId(id: String): Bson = Filters.equal("_id", id)
+
+  def keepAlive(id: String): Future[Boolean] =
+    collection
+      .updateOne(
+        filter = byId(id),
+        update = Updates.set("lastUpdated", Instant.now(clock))
+      )
+      .toFuture()
+      .map(
+        _ => true
+      )
+
+  def get(id: String): Future[Option[UserAnswers]] =
+    keepAlive(id).flatMap {
+      _ =>
+        collection
+          .find(byId(id))
+          .headOption()
+    }
+
+  def set(fatcaId: String, fiid: Option[String], answers: UserAnswers): Future[Boolean] = {
+
+    val id = fiid.fold(fatcaId)(
+      fiid => s"$fatcaId-$fiid"
+    )
+    val updatedAnswers = answers copy (id = id, lastUpdated = Instant.now(clock))
+
+    collection
+      .replaceOne(
+        filter = byId(updatedAnswers.id),
+        replacement = updatedAnswers,
+        options = ReplaceOptions().upsert(true)
+      )
+      .toFuture()
+      .map(
+        _ => true
+      )
+  }
+
+  def clear(fatcaId: String, fiid: Option[String]): Future[Boolean] = {
+    val id = fiid.fold(fatcaId)(
+      fiid => s"$fatcaId-$fiid"
+    )
+    collection
+      .deleteOne(byId(id))
+      .toFuture()
+      .map(
+        _ => true
+      )
+  }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -153,16 +153,16 @@ POST        /change-answers                                               contro
 GET         /registered-business/change-answers/:fiid                     controllers.changeFinancialInstitution.ChangeRegisteredFinancialInstitutionController.onPageLoad(fiid: String)
 POST        /registered-business/change-answers                           controllers.changeFinancialInstitution.ChangeRegisteredFinancialInstitutionController.confirmAndAdd()
 
-GET        /details-updated                                               controllers.DetailsUpdatedController.onPageLoad()
+GET         /details-updated                                              controllers.DetailsUpdatedController.onPageLoad()
 
-GET        /trust-urn                                                     controllers.addFinancialInstitution.TrustURNController.onPageLoad(mode: Mode = NormalMode)
-POST       /trust-urn                                                     controllers.addFinancialInstitution.TrustURNController.onSubmit(mode: Mode = NormalMode)
-GET        /change-trust-urn                                              controllers.addFinancialInstitution.TrustURNController.onPageLoad(mode: Mode = CheckMode)
-POST       /change-trust-urn                                              controllers.addFinancialInstitution.TrustURNController.onSubmit(mode: Mode = CheckMode)
+GET         /trust-urn                                                    controllers.addFinancialInstitution.TrustURNController.onPageLoad(mode: Mode = NormalMode)
+POST        /trust-urn                                                    controllers.addFinancialInstitution.TrustURNController.onSubmit(mode: Mode = NormalMode)
+GET         /change-trust-urn                                             controllers.addFinancialInstitution.TrustURNController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-trust-urn                                             controllers.addFinancialInstitution.TrustURNController.onSubmit(mode: Mode = CheckMode)
 
-GET        /problem/not-in-uk                                             controllers.NotInUKController.onPageLoad()
+GET         /problem/not-in-uk                                            controllers.NotInUKController.onPageLoad()
 
-GET        /identification-numbers                        controllers.addFinancialInstitution.WhichIdentificationNumbersController.onPageLoad(mode: Mode = NormalMode)
-POST       /identification-numbers                        controllers.addFinancialInstitution.WhichIdentificationNumbersController.onSubmit(mode: Mode = NormalMode)
-GET        /change-identification-numbers                  controllers.addFinancialInstitution.WhichIdentificationNumbersController.onPageLoad(mode: Mode = CheckMode)
-POST       /change-identification-numbers                  controllers.addFinancialInstitution.WhichIdentificationNumbersController.onSubmit(mode: Mode = CheckMode)
+GET         /identification-numbers                                       controllers.addFinancialInstitution.WhichIdentificationNumbersController.onPageLoad(mode: Mode = NormalMode)
+POST        /identification-numbers                                       controllers.addFinancialInstitution.WhichIdentificationNumbersController.onSubmit(mode: Mode = NormalMode)
+GET         /change-identification-numbers                                controllers.addFinancialInstitution.WhichIdentificationNumbersController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-identification-numbers                                controllers.addFinancialInstitution.WhichIdentificationNumbersController.onSubmit(mode: Mode = CheckMode)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,6 +80,7 @@ session {
 mongodb {
   uri                 = "mongodb://localhost:27017/"${appName}
   timeToLiveInSeconds = 900
+  changeAnswersTimeToLiveInSeconds = 3600
   encryptionEnabled = true
 }
 

--- a/it/test/repositories/ChangeUserAnswersRepositorySpec.scala
+++ b/it/test/repositories/ChangeUserAnswersRepositorySpec.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.{CryptoProvider, FrontendAppConfig}
+import models.CryptoType.{CryptoT, randomAesKey}
+import models.UserAnswers
+import org.mockito.Mockito.when
+import org.mongodb.scala.model.{Filters, IndexModel}
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
+import play.api.libs.json.Json
+import uk.gov.hmrc.crypto.Crypted
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ChangeUserAnswersRepositorySpec
+    extends AnyFreeSpec
+    with Matchers
+    with DefaultPlayMongoRepositorySupport[UserAnswers]
+    with ScalaFutures
+    with IntegrationPatience
+    with OptionValues
+    with MockitoSugar {
+
+  private val instant          = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+  private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
+
+  private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
+
+  private val mockAppConfig = mock[FrontendAppConfig]
+  when(mockAppConfig.changeAnswersCacheTtl) thenReturn 1
+
+  when(mockAppConfig.encryptionEnabled) thenReturn true
+
+  implicit val crypto: CryptoT = new CryptoProvider(Configuration("crypto.key" -> randomAesKey)).get()
+
+  override protected val repository = new ChangeUserAnswersRepository(
+    mongoComponent = mongoComponent,
+    appConfig = mockAppConfig,
+    clock = stubClock
+  )
+
+  ".set" - {
+
+    "must set the last updated time on the supplied user answers to `now`, and save them" in {
+
+      val expectedResult = userAnswers copy (id = "fatcaid-fiid", lastUpdated = instant)
+
+      val setResult     = repository.set("fatcaid", Some("fiid"), userAnswers).futureValue
+      val updatedRecord = find(Filters.equal("_id", "fatcaid-fiid")).futureValue.headOption.value
+
+      setResult mustEqual true
+      updatedRecord mustEqual expectedResult
+    }
+
+    "must encrypt the data" in {
+      repository.set("fatcaid", Some("fiid"), userAnswers).futureValue
+
+      val raw = mongoComponent.database
+        .getCollection("change-user-answers")
+        .find(Filters.equal("_id", "fatcaid-fiid"))
+        .headOption()
+        .futureValue
+
+      raw match {
+        case None => fail("db record not found")
+        case Some(ua) =>
+          val id            = ua.get("_id").head.asString.getValue
+          val rawData       = ua.get("data").get.asString.getValue
+          val decryptedData = crypto.decrypt(Crypted(rawData)).value
+
+          id mustBe "fatcaid-fiid"
+          Json.parse(decryptedData) mustBe userAnswers.data
+      }
+    }
+
+  }
+
+  ".get" - {
+
+    "when there is a record for this id" - {
+
+      "must update the lastUpdated time and get the record" in {
+
+        insert(userAnswers).futureValue
+
+        val result         = repository.get(userAnswers.id).futureValue
+        val expectedResult = userAnswers copy (lastUpdated = instant)
+
+        result.value mustEqual expectedResult
+      }
+    }
+
+    "when there is no record for this id" - {
+
+      "must return None" in {
+
+        repository.get("id that does not exist").futureValue must not be defined
+      }
+    }
+  }
+
+  ".clear" - {
+
+    "must remove a record" in {
+
+      insert(userAnswers.copy(id = "fatcaid-fiid")).futureValue
+
+      val result = repository.clear("fatcaid", Some("fiid")).futureValue
+
+      result mustEqual true
+      repository.get(userAnswers.id).futureValue must not be defined
+    }
+
+    "must return true when there is no record to remove" in {
+      val result = repository.clear("unknown", None).futureValue
+
+      result mustEqual true
+    }
+  }
+
+  ".keepAlive" - {
+
+    "when there is a record for this id" - {
+
+      "must update its lastUpdated to `now` and return true" in {
+
+        insert(userAnswers).futureValue
+
+        val result = repository.keepAlive(userAnswers.id).futureValue
+
+        val expectedUpdatedAnswers = userAnswers copy (lastUpdated = instant)
+
+        result mustEqual true
+        val updatedAnswers = find(Filters.equal("_id", userAnswers.id)).futureValue.headOption.value
+        updatedAnswers mustEqual expectedUpdatedAnswers
+      }
+    }
+
+    "when there is no record for this id" - {
+
+      "must return true" in {
+
+        repository.keepAlive("id that does not exist").futureValue mustEqual true
+      }
+    }
+  }
+
+}

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -28,7 +28,7 @@ import play.api.inject.bind
 import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import services.{FinancialInstitutionsService, SubscriptionService}
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.IndexView
@@ -39,14 +39,18 @@ class IndexControllerSpec extends SpecBase {
 
   val mockSubscriptionService: SubscriptionService                   = mock[SubscriptionService]
   val mockSessionRepository: SessionRepository                       = mock[SessionRepository]
+  val mockChangeUserAnswersRepository: ChangeUserAnswersRepository   = mock[ChangeUserAnswersRepository]
   val mockAppConfig: FrontendAppConfig                               = mock[FrontendAppConfig]
   val mockFinancialInstitutionsService: FinancialInstitutionsService = mock[FinancialInstitutionsService]
 
   when(mockSessionRepository.get(any())) thenReturn Future.successful(Some(emptyUserAnswers))
   when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+  when(mockChangeUserAnswersRepository.get(any())) thenReturn Future.successful(None)
+  when(mockChangeUserAnswersRepository.set(any(), any(), any())) thenReturn Future.successful(true)
   when(mockAppConfig.changeIndividualDetailsUrl) thenReturn "/change-contact/individual/details"
   when(mockAppConfig.changeOrganisationDetailsUrl) thenReturn "/change-contact/organisation/details"
   when(mockAppConfig.feedbackUrl(any[RequestHeader]())) thenReturn "test"
+  when(mockAppConfig.changeAnswersCacheTtl).thenReturn(3600)
 
   when(mockFinancialInstitutionsService.getListOfFinancialInstitutions(any())(any[HeaderCarrier](), any[ExecutionContext]()))
     .thenReturn(Future.successful(testFiDetails))

--- a/test/controllers/addFinancialInstitution/FirstContactEmailControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/FirstContactEmailControllerSpec.scala
@@ -28,7 +28,7 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import repositories.SessionRepository
+import repositories.{ChangeUserAnswersRepository, SessionRepository}
 import views.html.addFinancialInstitution.FirstContactEmailView
 
 import scala.concurrent.Future
@@ -88,14 +88,16 @@ class FirstContactEmailControllerSpec extends SpecBase with MockitoSugar {
     "must redirect to the next page when valid data is submitted" in {
 
       val mockSessionRepository = mock[SessionRepository]
-
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      val mockChangeUserAnswersRepository = mock[ChangeUserAnswersRepository]
+      when(mockChangeUserAnswersRepository.set(any(), any(), any())) thenReturn Future.successful(true)
 
       val application =
         applicationBuilder(userAnswers = Some(ua))
           .overrides(
             bind[Navigator].toInstance(new FakeNavigator(onwardRoute)),
-            bind[SessionRepository].toInstance(mockSessionRepository)
+            bind[SessionRepository].toInstance(mockSessionRepository),
+            bind[ChangeUserAnswersRepository].toInstance(mockChangeUserAnswersRepository)
           )
           .build()
 


### PR DESCRIPTION
Integrate the ChangeUserAnswersRepository across controllers and services to handle interim user answer updates for financial institution details. This ensures better tracking of in-progress changes and aligns data persistence logic across the application.