### PR TITLE
DAC6-3417: Fix incorrect variable in repository update

### DIFF
--- a/app/controllers/addFinancialInstitution/registeredBusiness/IsThisYourBusinessNameController.scala
+++ b/app/controllers/addFinancialInstitution/registeredBusiness/IsThisYourBusinessNameController.scala
@@ -93,8 +93,8 @@ class IsThisYourBusinessNameController @Inject() (
                       updatedAnswers <- Future.fromTry(request.userAnswers.set(IsThisYourBusinessNamePage, value))
                       updatedFIName  <- setFIName(value, fiName, updatedAnswers)
                       _              <- sessionRepository.set(updatedFIName)
-                      _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedAnswers)
-                    } yield Redirect(navigator.nextPage(IsThisYourBusinessNamePage, mode, updatedAnswers))
+                      _              <- changeUserAnswersRepository.set(request.fatcaId, updatedAnswers.get(ChangeFiDetailsInProgressId), updatedFIName)
+                    } yield Redirect(navigator.nextPage(IsThisYourBusinessNamePage, mode, updatedFIName))
                 )
           }
       }


### PR DESCRIPTION
Updated the repository call to use the correct variable `updatedFIName` instead of `updatedAnswers`. This ensures the correct data is saved and prevents potential inconsistencies.