### PR TITLE
DAC6-3513: Update FI details persistence logic

### DIFF
--- a/app/controllers/changeFinancialInstitution/ChangeFinancialInstitutionController.scala
+++ b/app/controllers/changeFinancialInstitution/ChangeFinancialInstitutionController.scala
@@ -71,10 +71,11 @@ class ChangeFinancialInstitutionController @Inject() (
                     Future.successful(Redirect(controllers.routes.SomeInformationMissingController.onPageLoad()))
                 }
               case _ =>
-                val hasChanges = financialInstitutionUpdateService.fiDetailsHasChanged(userAnswers, fiDetails)
                 financialInstitutionUpdateService
                   .populateAndSaveFiDetails(userAnswers, fiDetails)
-                  .map(createPage(fiid, _, hasChanges = hasChanges))
+                  .map {
+                    case (ua, fromChangedAnswers) => createPage(fiid, ua, hasChanges = fromChangedAnswers)
+                  }
                   .recoverWith {
                     exception =>
                       logger.error(s"Failed to populate and save FI details to user answers for subscription Id: [${request.fatcaId}] and FI Id [$fiid]",
@@ -103,7 +104,7 @@ class ChangeFinancialInstitutionController @Inject() (
           _ => financialInstitutionUpdateService.clearUserAnswers(request.userAnswers)
         )
         .flatMap(
-          _ => changeUserAnswersRepository.clear(request.userId, request.userAnswers.get(ChangeFiDetailsInProgressId))
+          _ => changeUserAnswersRepository.clear(request.fatcaId, request.userAnswers.get(ChangeFiDetailsInProgressId))
         )
         .map(
           _ => Redirect(controllers.routes.DetailsUpdatedController.onPageLoad()).flashing("fiName" -> fiName)

--- a/test/controllers/changeFinancialInstitution/ChangeFinancialInstitutionControllerSpec.scala
+++ b/test/controllers/changeFinancialInstitution/ChangeFinancialInstitutionControllerSpec.scala
@@ -310,6 +310,6 @@ class ChangeFinancialInstitutionControllerSpec
   private def mockSuccessfulUserAnswersPersistence(userAnswers: UserAnswers, fiDetail: FIDetail) =
     when(
       mockFinancialInstitutionUpdateService.populateAndSaveFiDetails(mockitoEq(userAnswers), mockitoEq(fiDetail))
-    ).thenReturn(Future.successful(userAnswers))
+    ).thenReturn(Future.successful((userAnswers, false)))
 
 }

--- a/test/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionControllerSpec.scala
+++ b/test/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionControllerSpec.scala
@@ -307,6 +307,6 @@ class ChangeRegisteredFinancialInstitutionControllerSpec
   private def mockSuccessfulUserAnswersPersistence(userAnswers: UserAnswers, fiDetail: FIDetail) =
     when(
       mockFinancialInstitutionUpdateService.populateAndSaveRegisteredFiDetails(mockitoEq(userAnswers), mockitoEq(fiDetail))
-    ).thenReturn(Future.successful(userAnswers))
+    ).thenReturn(Future.successful((userAnswers, false)))
 
 }

--- a/test/services/FinancialInstitutionUpdateServiceSpec.scala
+++ b/test/services/FinancialInstitutionUpdateServiceSpec.scala
@@ -65,7 +65,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(country))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(ukCountryCodes)
 
-            val populatedUserAnswers = service.populateAndSaveFiDetails(emptyUserAnswers, fiDetails).futureValue
+            val (populatedUserAnswers, _) = service.populateAndSaveFiDetails(emptyUserAnswers, fiDetails).futureValue
 
             verify(mockSessionRepository, times(1)).set(populatedUserAnswers)
             verifyUserAnswersMatchFIDetails(fiDetails, populatedUserAnswers, isUkAddress)
@@ -94,7 +94,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (populatedUserAnswers, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
 
@@ -109,9 +109,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(NameOfFinancialInstitutionPage, UUID.randomUUID() + "suffix")
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
@@ -126,9 +128,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.countryCodesForUkCountries)
               .thenReturn(Set(fiDetails.AddressDetails.CountryCode.value, newAddress.CountryCode.value))
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .removePage(NonUkAddressPage)
               .removePage(SelectedAddressLookupPage)
               .withPage(UkAddressPage, newAddress.toAddress(mockCountryListFactory).value)
@@ -145,9 +149,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.countryCodesForUkCountries)
               .thenReturn(Set(fiDetails.AddressDetails.CountryCode.value, newAddress.CountryCode.value))
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .removePage(UkAddressPage)
               .removePage(SelectedAddressLookupPage)
               .withPage(NonUkAddressPage, newAddress.toAddress(mockCountryListFactory).value)
@@ -164,9 +170,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.countryCodesForUkCountries)
               .thenReturn(Set(fiDetails.AddressDetails.CountryCode.value, Country.GB.code))
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .removePage(UkAddressPage)
               .removePage(NonUkAddressPage)
               .withPage(SelectedAddressLookupPage, newAddress)
@@ -182,9 +190,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(FirstContactNamePage, UUID.randomUUID() + "suffix")
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
@@ -198,9 +208,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(FirstContactEmailPage, UUID.randomUUID() + "suffix")
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
@@ -214,9 +226,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(FirstContactHavePhonePage, fiDetails.PrimaryContactDetails.map(_.PhoneNumber).isEmpty)
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
@@ -230,9 +244,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, fiDetails.SecondaryContactDetails.isEmpty)
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetails) mustBe true
@@ -248,9 +264,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
-              .populateAndSaveFiDetails(emptyUserAnswers, fiDetailsWithUTR)
+            val (result, _) = service
+              .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(WhatIsUniqueTaxpayerReferencePage, UniqueTaxpayerReference(UUID.randomUUID().toString))
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetailsWithUTR) mustBe true
@@ -266,9 +284,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
-              .populateAndSaveFiDetails(emptyUserAnswers, fiDetailsWithGIIN)
+            val (result, _) = service
+              .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(WhatIsGIINPage, GIINumber(UUID.randomUUID().toString))
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetailsWithGIIN) mustBe true
@@ -284,9 +304,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(FirstContactHavePhonePage, false)
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetailsWithSecondaryContact) mustBe true
@@ -302,9 +324,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(FirstContactHavePhonePage, true)
 
             service.fiDetailsHasChanged(populatedUserAnswers, fiDetailsWithSecondaryContact) mustBe true
@@ -320,9 +344,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, true)
               .withPage(SecondContactNamePage, UUID.randomUUID().toString + "suffix")
               .withPage(SecondContactEmailPage, email)
@@ -341,9 +367,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, true)
               .withPage(SecondContactNamePage, name)
               .withPage(SecondContactEmailPage, UUID.randomUUID().toString + "suffix")
@@ -362,9 +390,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, true)
               .withPage(SecondContactNamePage, name)
               .withPage(SecondContactEmailPage, email)
@@ -384,9 +414,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, false)
               .withPage(SecondContactNamePage, name)
               .withPage(SecondContactEmailPage, email)
@@ -405,9 +437,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, true)
               .withPage(SecondContactNamePage, name)
               .withPage(SecondContactEmailPage, email)
@@ -426,9 +460,11 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
 
-            val populatedUserAnswers = service
+            val (result, _) = service
               .populateAndSaveFiDetails(emptyUserAnswers, fiDetails)
               .futureValue
+
+            val populatedUserAnswers = result
               .withPage(SecondContactExistsPage, true)
               .withPage(SecondContactNamePage, name)
               .withPage(SecondContactEmailPage, email)


### PR DESCRIPTION
Modified `populateAndSaveFiDetails` and `populateAndSaveRegisteredFiDetails` to return a tuple with user answers and change status. Updated related controller and test code to handle the new return type appropriately.