### PR TITLE
DAC6-3482 - Change FI - User entered name should reflect on /change-name

### DIFF
--- a/app/pages/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNamePage.scala
+++ b/app/pages/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNamePage.scala
@@ -31,7 +31,7 @@ case object IsThisYourBusinessNamePage extends QuestionPage[Boolean] {
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
     value match {
-      case Some(false) =>
+      case Some(true) =>
         val pagesToRemove = Seq(NameOfFinancialInstitutionPage)
         removePages(pagesToRemove, userAnswers)
 

--- a/test/models/UserAnswersSpec.scala
+++ b/test/models/UserAnswersSpec.scala
@@ -28,13 +28,13 @@ class UserAnswersSpec extends SpecBase with Matchers {
       val usersAnswers = emptyUserAnswers
         .withPage(IsThisYourBusinessNamePage, true)
         .withPage(NameOfFinancialInstitutionPage, "test")
-      val result = usersAnswers.set(IsThisYourBusinessNamePage, false).get
+      val result = usersAnswers.set(IsThisYourBusinessNamePage, true).get
       result.data.value must not contain key(NameOfFinancialInstitutionPage.toString)
     }
 
     "should not cleanup when cleanup flag is false" in {
       val usersAnswers = emptyUserAnswers
-        .withPage(IsThisYourBusinessNamePage, true)
+        .withPage(IsThisYourBusinessNamePage, false)
         .withPage(NameOfFinancialInstitutionPage, "test")
       val result = usersAnswers.set(IsThisYourBusinessNamePage, false, cleanup = false).get
       result.data.value must contain key NameOfFinancialInstitutionPage.toString

--- a/test/pages/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNamePageSpec.scala
+++ b/test/pages/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNamePageSpec.scala
@@ -31,13 +31,13 @@ class IsThisYourBusinessNamePageSpec extends PageBehaviours {
 
   "cleanup" - {
 
-    "when false" in {
-      val result = IsThisYourBusinessNamePage.cleanup(Some(false), userAnswersForAddFI)
+    "when true" in {
+      val result = IsThisYourBusinessNamePage.cleanup(Some(true), userAnswersForAddFI)
 
       result.get.data.value must not contain key(NameOfFinancialInstitutionPage.toString)
     }
-    "when true" in {
-      val result = IsThisYourBusinessNamePage.cleanup(Some(true), userAnswersForAddFI)
+    "when false" in {
+      val result = IsThisYourBusinessNamePage.cleanup(Some(false), userAnswersForAddFI)
       result.get mustBe userAnswersForAddFI
     }
   }


### PR DESCRIPTION
flip logic on IsThisYourBusinessNamePage as NameOfFinancialInstitutionPage is not required when name is correct