### PR TITLE
DAC6-3538: Enable form autoComplete

### DIFF
--- a/.g8/checkboxPage/app/views/$className$View.scala.html
+++ b/.g8/checkboxPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/datePage/app/views/$className$View.scala.html
+++ b/.g8/datePage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))

--- a/.g8/intPage/app/views/$className$View.scala.html
+++ b/.g8/intPage/app/views/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/multipleQuestionsPage/app/views/$className$View.scala.html
+++ b/.g8/multipleQuestionsPage/app/views/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/radioButtonPage/app/views/$className$View.scala.html
+++ b/.g8/radioButtonPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/yesNoPage/app/views/$className$View.scala.html
+++ b/.g8/yesNoPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/RemoveAreYouSureView.scala.html
+++ b/app/views/RemoveAreYouSureView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = title(form, messages("removeAreYouSure.title"))) {
 
-    @formHelper(action = routes.RemoveAreYouSureController.onSubmit(id), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.RemoveAreYouSureController.onSubmit(id), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/YourFinancialInstitutionsView.scala.html
+++ b/app/views/YourFinancialInstitutionsView.scala.html
@@ -52,7 +52,7 @@
         </div>
     }
 
-    @formHelper(action = controllers.routes.YourFinancialInstitutionsController.onSubmit(), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.routes.YourFinancialInstitutionsController.onSubmit(), Symbol("autoComplete") -> "on") {
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),

--- a/app/views/addFinancialInstitution/FirstContactEmailView.scala.html
+++ b/app/views/addFinancialInstitution/FirstContactEmailView.scala.html
@@ -31,7 +31,7 @@
 
 @layout(pageTitle = title(form, messages("firstContactEmail.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactEmailController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactEmailController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/FirstContactHavePhoneView.scala.html
+++ b/app/views/addFinancialInstitution/FirstContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("firstContactHavePhone.title.business"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/FirstContactNameView.scala.html
+++ b/app/views/addFinancialInstitution/FirstContactNameView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("firstContactName.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/FirstContactPhoneNumberView.scala.html
+++ b/app/views/addFinancialInstitution/FirstContactPhoneNumberView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("firstContactPhoneNumber.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactPhoneNumberController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.FirstContactPhoneNumberController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/HaveGIINView.scala.html
+++ b/app/views/addFinancialInstitution/HaveGIINView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("haveGIIN.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.HaveGIINController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.HaveGIINController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/IsTheAddressCorrectView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("isTheAddressCorrect.title", fiName))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.IsTheAddressCorrectController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.IsTheAddressCorrectController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNameView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/IsThisYourBusinessNameView.scala.html
@@ -27,7 +27,7 @@
 
 @layout(pageTitle = title(form, messages("isThisYourBusinessName.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.IsThisYourBusinessNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.IsThisYourBusinessNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/IsRegisteredBusiness/ReportForRegisteredBusinessView.scala.html
+++ b/app/views/addFinancialInstitution/IsRegisteredBusiness/ReportForRegisteredBusinessView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("reportForRegisteredBusiness.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.ReportForRegisteredBusinessController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.registeredBusiness.routes.ReportForRegisteredBusinessController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/IsThisAddressView.scala.html
+++ b/app/views/addFinancialInstitution/IsThisAddressView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = title(form, messages("isThisAddress.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.IsThisAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.IsThisAddressController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/NameOfFinancialInstitutionView.scala.html
+++ b/app/views/addFinancialInstitution/NameOfFinancialInstitutionView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("nameOfFinancialInstitution.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.NameOfFinancialInstitutionController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.NameOfFinancialInstitutionController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/PostcodeView.scala.html
+++ b/app/views/addFinancialInstitution/PostcodeView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("postcode.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.PostcodeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.PostcodeController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SecondContactCanWePhoneView.scala.html
+++ b/app/views/addFinancialInstitution/SecondContactCanWePhoneView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("secondContactCanWePhone.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactCanWePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactCanWePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SecondContactEmailView.scala.html
+++ b/app/views/addFinancialInstitution/SecondContactEmailView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("secondContactEmail.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactEmailController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactEmailController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SecondContactExistsView.scala.html
+++ b/app/views/addFinancialInstitution/SecondContactExistsView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("secondContact.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactExistsController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactExistsController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SecondContactNameView.scala.html
+++ b/app/views/addFinancialInstitution/SecondContactNameView.scala.html
@@ -31,7 +31,7 @@
 
 @layout(pageTitle = title(form, messages("secondContactName.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SecondContactPhoneNumberView.scala.html
+++ b/app/views/addFinancialInstitution/SecondContactPhoneNumberView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("secondContactPhoneNumber.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactPhoneNumberController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SecondContactPhoneNumberController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SelectAddressView.scala.html
+++ b/app/views/addFinancialInstitution/SelectAddressView.scala.html
@@ -31,7 +31,7 @@
 
 @layout(pageTitle = title(form, messages("selectAddress.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SelectAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SelectAddressController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/SelectAddressView.scala.html
+++ b/app/views/addFinancialInstitution/SelectAddressView.scala.html
@@ -31,7 +31,7 @@
 
 @layout(pageTitle = title(form, messages("selectAddress.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.SelectAddressController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.SelectAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/UkAddressView.scala.html
+++ b/app/views/addFinancialInstitution/UkAddressView.scala.html
@@ -33,7 +33,7 @@
 
 @layout(pageTitle = title(form, messages("ukAddress.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.UkAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.UkAddressController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
     @if(form.errors.nonEmpty) {
         @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/WhatIsCompanyRegistrationNumberView.scala.html
+++ b/app/views/addFinancialInstitution/WhatIsCompanyRegistrationNumberView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = title(form, messages("whatIsCompanyRegistrationNumber.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsCompanyRegistrationNumberController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsCompanyRegistrationNumberController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/WhatIsGIINView.scala.html
+++ b/app/views/addFinancialInstitution/WhatIsGIINView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("whatIsGIIN.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsGIINController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsGIINController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/WhatIsUniqueTaxpayerReferenceView.scala.html
+++ b/app/views/addFinancialInstitution/WhatIsUniqueTaxpayerReferenceView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = title(form, messages("whatIsUniqueTaxpayerReference.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsUniqueTaxpayerReferenceController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.WhatIsUniqueTaxpayerReferenceController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/addFinancialInstitution/WhichIdentificationNumbersView.scala.html
+++ b/app/views/addFinancialInstitution/WhichIdentificationNumbersView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("whichIdentificationNumbers.title"))) {
 
-    @formHelper(action = controllers.addFinancialInstitution.routes.WhichIdentificationNumbersController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.addFinancialInstitution.routes.WhichIdentificationNumbersController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))


### PR DESCRIPTION
Updated formHelper instances across multiple views to enable autoComplete by setting Symbol("autoComplete") to "on". This improves user experience by allowing browsers to suggest and autofill inputs where applicable.