### PR TITLE
DAC6-3591: Handle no matching records error in FinancialInstitutionsS…

### DIFF
--- a/app/connectors/FinancialInstitutionsConnector.scala
+++ b/app/connectors/FinancialInstitutionsConnector.scala
@@ -22,6 +22,7 @@ import play.api.i18n.Lang.logger
 import play.api.libs.json.{Json, Writes}
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
+import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -209,6 +209,15 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
   }
 """
 
+  val testViewFIDetailsErrorBody =
+    """{
+      |  "errorDetail": {
+      |    "errorCode": "001",
+      |    "errorMessage": "No matching records found"
+      |  }
+      |}
+      |""".stripMargin
+
   val testAddress: Address                 = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
   val testAddressResponse: AddressResponse = AddressResponse("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB.code)
 

--- a/test/connectors/FinancialInstitutionsConnectorSpec.scala
+++ b/test/connectors/FinancialInstitutionsConnectorSpec.scala
@@ -20,6 +20,7 @@ import base.SpecBase
 import generators.Generators
 import helpers.WireMockServerHandler
 import models.FinancialInstitutions.{AddressDetails, ContactDetails, CreateFIDetails, RemoveFIDetail}
+import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.Application
 import play.api.http.Status.{OK, SERVICE_UNAVAILABLE}
@@ -100,10 +101,10 @@ class FinancialInstitutionsConnectorSpec extends SpecBase with WireMockServerHan
         result.status mustBe OK
       }
 
-      "must return Left(ErrorDetails) when the response status is not OK" in {
+      "must return ErrorDetails and correct status code when the response status is not OK" in {
         val errorResponseJson =
           """{
-            |"ErrorDetails": {
+            |"errorDetails": {
             |    "timestamp": "2016-08-16T18:15:41Z",
             |    "correlationId": "",
             |    "errorCode": "503"
@@ -114,9 +115,9 @@ class FinancialInstitutionsConnectorSpec extends SpecBase with WireMockServerHan
           SERVICE_UNAVAILABLE,
           errorResponseJson
         )
-        val result = connector.addOrUpdateFI(createFIDetails).failed.futureValue
+        val result = connector.addOrUpdateFI(createFIDetails).futureValue
 
-        result mustBe a[UpstreamErrorResponse]
+        result.status mustBe SERVICE_UNAVAILABLE
       }
     }
     "must return status as OK for removeFi" in {

--- a/test/services/FinancialInstitutionsServiceSpec.scala
+++ b/test/services/FinancialInstitutionsServiceSpec.scala
@@ -26,7 +26,7 @@ import org.mockito.MockitoSugar.when
 import org.scalatestplus.mockito.MockitoSugar._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import pages.changeFinancialInstitution.ChangeFiDetailsInProgressId
-import play.api.http.Status.OK
+import play.api.http.Status.{OK, UNPROCESSABLE_ENTITY}
 import play.api.libs.json._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 
@@ -49,6 +49,15 @@ class FinancialInstitutionsServiceSpec extends SpecBase with ModelGenerators wit
       when(mockConnector.viewFis(subscriptionId)).thenReturn(mockResponse)
       val result: Future[Seq[FIDetail]] = sut.getListOfFinancialInstitutions(subscriptionId)
       result.futureValue mustBe testFiDetails
+    }
+
+    "getListOfFinancialInstitutions return empty response when no matching records error" in {
+      val subscriptionId = "XE5123456789"
+      val mockResponse   = Future.successful(HttpResponse(UNPROCESSABLE_ENTITY, testViewFIDetailsErrorBody))
+
+      when(mockConnector.viewFis(subscriptionId)).thenReturn(mockResponse)
+      val result: Future[Seq[FIDetail]] = sut.getListOfFinancialInstitutions(subscriptionId)
+      result.futureValue mustBe Seq.empty
     }
 
     "getFinancialInstitution" - {


### PR DESCRIPTION
…ervice

Updated FinancialInstitutionsService to handle UNPROCESSABLE_ENTITY (422) responses with a specific error code by returning an empty list. Added new test cases and mock data to validate this behavior in the service spec.