### PR TITLE
DAC6-3602: Remove IsFATCAReporting field

### DIFF
--- a/app/models/FinancialInstitutions/FIDetail.scala
+++ b/app/models/FinancialInstitutions/FIDetail.scala
@@ -25,7 +25,6 @@ sealed trait BaseFIDetail {
   val SubscriptionID: String
   val TINDetails: Seq[TINDetails]
   val IsFIUser: Boolean
-  val IsFATCAReporting: Boolean
   val AddressDetails: AddressDetails
   val PrimaryContactDetails: Option[ContactDetails]
   val SecondaryContactDetails: Option[ContactDetails]
@@ -41,7 +40,6 @@ final case class FIDetail(
   SubscriptionID: String,
   TINDetails: Seq[TINDetails],
   IsFIUser: Boolean,
-  IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: Option[ContactDetails],
   SecondaryContactDetails: Option[ContactDetails]
@@ -102,7 +100,6 @@ final case class CreateFIDetails(
   SubscriptionID: String,
   TINDetails: Seq[TINDetails],
   IsFIUser: Boolean,
-  IsFATCAReporting: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: Option[ContactDetails],
   SecondaryContactDetails: Option[ContactDetails]

--- a/app/services/FinancialInstitutionsService.scala
+++ b/app/services/FinancialInstitutionsService.scala
@@ -114,7 +114,6 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       SubscriptionID = subscriptionId,
       TINDetails = extractTinDetails(userAnswers),
       IsFIUser = userAnswers.get(ReportForRegisteredBusinessPage).contains(true),
-      IsFATCAReporting = true,
       AddressDetails = address,
       PrimaryContactDetails = extractPrimaryContactDetails(userAnswers),
       SecondaryContactDetails = extractSecondaryContactDetails(userAnswers)
@@ -131,7 +130,6 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       SubscriptionID = subscriptionId,
       TINDetails = extractTinDetails(userAnswers),
       IsFIUser = userAnswers.get(ReportForRegisteredBusinessPage).contains(true),
-      IsFATCAReporting = true,
       AddressDetails = address,
       PrimaryContactDetails = extractPrimaryContactDetails(userAnswers),
       SecondaryContactDetails = extractSecondaryContactDetails(userAnswers)

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -131,7 +131,6 @@ trait ModelGenerators extends RegexConstants with Generators {
       tin                     <- stringOfLength(10)
       tinDetails              <- Gen.const(List(TINDetails(tinType, tin, "GB")))
       isFIUser                <- arbitrary[Boolean]
-      isFATCAReporting        <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
       secondaryContactDetails <- Gen.option(arbitrary[ContactDetails])
@@ -141,7 +140,6 @@ trait ModelGenerators extends RegexConstants with Generators {
       SubscriptionID = subscriptionId,
       TINDetails = tinDetails,
       IsFIUser = isFIUser,
-      IsFATCAReporting = isFATCAReporting,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),
       SecondaryContactDetails = secondaryContactDetails

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -102,7 +102,6 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
       "[subscriptionId]",
       List(TINDetails(GIIN, "689355555", "GB")),
       IsFIUser = true,
-      IsFATCAReporting = true,
       AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
       Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
       Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
@@ -116,7 +115,6 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         "[subscriptionId]",
         List(TINDetails(GIIN, "689355555", "GB")),
         IsFIUser = true,
-        IsFATCAReporting = true,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
         Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
@@ -127,7 +125,6 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         "[subscriptionId]",
         List(TINDetails(GIIN, "689344444", "GB")),
         IsFIUser = false,
-        IsFATCAReporting = true,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Foo Bar", "fbar@example.com", Some("0223458888"))),
         Some(ContactDetails("Foobar Baz", "fbaz@example.com", Some("0123456789")))
@@ -151,7 +148,6 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
               }
             ],
             "IsFIUser": true,
-            "IsFATCAReporting": true,
             "AddressDetails": {
               "AddressLine1": "22",
               "AddressLine2": "High Street",
@@ -183,7 +179,6 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
               }
             ],
             "IsFIUser": false,
-            "IsFATCAReporting": true,
             "AddressDetails": {
               "AddressLine1": "22",
               "AddressLine2": "High Street",

--- a/test/connectors/FinancialInstitutionsConnectorSpec.scala
+++ b/test/connectors/FinancialInstitutionsConnectorSpec.scala
@@ -46,7 +46,6 @@ class FinancialInstitutionsConnectorSpec extends SpecBase with WireMockServerHan
     SubscriptionID = "XE512345678",
     TINDetails = Seq.empty,
     IsFIUser = true,
-    IsFATCAReporting = false,
     AddressDetails = AddressDetails(
       AddressLine1 = "line 1",
       AddressLine2 = None,


### PR DESCRIPTION
Eliminated the IsFATCAReporting field and all related code references to simplify the FinancialInstitutions data model. This change reduces redundancy and improves code maintainability across the models, services, and test cases.