### PR TITLE
DAC6-3609: Refactor FI logic to separate GIIN

### DIFF
--- a/app/controllers/FIRemovedController.scala
+++ b/app/controllers/FIRemovedController.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import controllers.actions._
-import pages.InstitutionDetail
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.FinancialInstitutionsService
@@ -25,7 +24,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.ContactHelper
 import views.html.FIRemovedView
 
-import java.time.{Clock, LocalDate, LocalTime, ZoneId, ZonedDateTime}
+import java.time.{Clock, ZoneId, ZonedDateTime}
 import javax.inject.Inject
 
 class FIRemovedController @Inject() (

--- a/app/models/FinancialInstitutions/FIDetail.scala
+++ b/app/models/FinancialInstitutions/FIDetail.scala
@@ -24,6 +24,7 @@ sealed trait BaseFIDetail {
   val FIName: String
   val SubscriptionID: String
   val TINDetails: Seq[TINDetails]
+  val GIIN: Option[String]
   val IsFIUser: Boolean
   val AddressDetails: AddressDetails
   val PrimaryContactDetails: Option[ContactDetails]
@@ -39,6 +40,7 @@ final case class FIDetail(
   FIName: String,
   SubscriptionID: String,
   TINDetails: Seq[TINDetails],
+  GIIN: Option[String],
   IsFIUser: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: Option[ContactDetails],
@@ -99,6 +101,7 @@ final case class CreateFIDetails(
   FIName: String,
   SubscriptionID: String,
   TINDetails: Seq[TINDetails],
+  GIIN: Option[String],
   IsFIUser: Boolean,
   AddressDetails: AddressDetails,
   PrimaryContactDetails: Option[ContactDetails],

--- a/app/models/FinancialInstitutions/TINType.scala
+++ b/app/models/FinancialInstitutions/TINType.scala
@@ -27,11 +27,10 @@ sealed trait TINType
 object TINType extends Enumerable.Implicits {
 
   case object UTR extends TINType
-  case object GIIN extends TINType
   case object CRN extends TINType
   case object TRN extends TINType
 
-  val allValues: IndexedSeq[TINType]     = IndexedSeq(UTR, CRN, TRN, GIIN)
+  val allValues: IndexedSeq[TINType]     = IndexedSeq(UTR, CRN, TRN)
   val whichIdValues: IndexedSeq[TINType] = IndexedSeq(UTR, CRN, TRN)
 
   def checkboxItems(implicit messages: Messages): Seq[CheckboxItem] = {

--- a/app/services/FinancialInstitutionsService.scala
+++ b/app/services/FinancialInstitutionsService.scala
@@ -17,7 +17,7 @@
 package services
 
 import connectors.FinancialInstitutionsConnector
-import models.FinancialInstitutions.TINType.{CRN, GIIN, TRN, UTR}
+import models.FinancialInstitutions.TINType.{CRN, TRN, UTR}
 import models.FinancialInstitutions._
 import models.UserAnswers
 import pages.addFinancialInstitution.IsRegisteredBusiness.{FetchedRegisteredAddressPage, ReportForRegisteredBusinessPage}
@@ -113,6 +113,7 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = extractTinDetails(userAnswers),
+      GIIN = userAnswers.get(WhatIsGIINPage).map(_.value),
       IsFIUser = userAnswers.get(ReportForRegisteredBusinessPage).contains(true),
       AddressDetails = address,
       PrimaryContactDetails = extractPrimaryContactDetails(userAnswers),
@@ -129,6 +130,7 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = extractTinDetails(userAnswers),
+      GIIN = userAnswers.get(WhatIsGIINPage).map(_.value),
       IsFIUser = userAnswers.get(ReportForRegisteredBusinessPage).contains(true),
       AddressDetails = address,
       PrimaryContactDetails = extractPrimaryContactDetails(userAnswers),
@@ -148,12 +150,7 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       case Some(trn) => Seq(TINDetails(TRN, trn.value, "GB"))
       case _         => Seq.empty
     }
-
-    val giin = userAnswers.get(WhatIsGIINPage) match {
-      case Some(giin) => Seq(TINDetails(GIIN, giin.value, "US"))
-      case _          => Seq.empty
-    }
-    utr ++ crn ++ trn ++ giin
+    utr ++ crn ++ trn
   }
 
   private def extractPrimaryContactDetails(userAnswers: UserAnswers): Option[ContactDetails] = for {

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -127,9 +127,10 @@ trait ModelGenerators extends RegexConstants with Generators {
       fiId                    <- stringOfLength(15)
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
-      tinType                 <- Gen.oneOf(TINType.UTR, TINType.CRN, TINType.TRN, TINType.GIIN)
+      tinType                 <- Gen.oneOf(TINType.UTR, TINType.CRN, TINType.TRN)
       tin                     <- stringOfLength(10)
       tinDetails              <- Gen.const(List(TINDetails(tinType, tin, "GB")))
+      giin                    <- Gen.option(stringOfLength(10))
       isFIUser                <- arbitrary[Boolean]
       addressDetails          <- arbitrary[AddressDetails]
       primaryContactDetails   <- arbitrary[ContactDetails]
@@ -139,6 +140,7 @@ trait ModelGenerators extends RegexConstants with Generators {
       FIName = fiName,
       SubscriptionID = subscriptionId,
       TINDetails = tinDetails,
+      GIIN = giin,
       IsFIUser = isFIUser,
       AddressDetails = addressDetails,
       PrimaryContactDetails = Some(primaryContactDetails),

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,7 +17,6 @@
 package base
 
 import controllers.actions._
-import models.FinancialInstitutions.TINType.GIIN
 import models.FinancialInstitutions._
 import models.{Address, AddressLookup, AddressResponse, Country, GIINumber, UniqueTaxpayerReference, UserAnswers}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -101,7 +100,8 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
       s"$testFiid",
       "First FI",
       "[subscriptionId]",
-      List(TINDetails(GIIN, "689355555", "GB")),
+      List(),
+      Some("689355555"),
       IsFIUser = true,
       AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
       Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
@@ -114,7 +114,8 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         "683373339",
         "First FI",
         "[subscriptionId]",
-        List(TINDetails(GIIN, "689355555", "GB")),
+        List(),
+        Some("689355555"),
         IsFIUser = true,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
@@ -124,7 +125,8 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         "683373300",
         "Second FI",
         "[subscriptionId]",
-        List(TINDetails(GIIN, "689344444", "GB")),
+        List(),
+        Some("689344444"),
         IsFIUser = false,
         AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Foo Bar", "fbar@example.com", Some("0223458888"))),
@@ -141,13 +143,8 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
             "FIID": "683373339",
             "FIName": "First FI",
             "SubscriptionID": "[subscriptionId]",
-            "TINDetails": [
-              {
-                "TINType": "GIIN",
-                "TIN": "689355555",
-                "IssuedBy": "GB"
-              }
-            ],
+            "TINDetails": [],
+            "GIIN": "689355555",
             "IsFIUser": true,
             "AddressDetails": {
               "AddressLine1": "22",
@@ -172,13 +169,8 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
             "FIID": "683373300",
             "FIName": "Second FI",
             "SubscriptionID": "[subscriptionId]",
-            "TINDetails": [
-              {
-                "TINType": "GIIN",
-                "TIN": "689344444",
-                "IssuedBy": "GB"
-              }
-            ],
+            "TINDetails": [],
+            "GIIN": "689344444",
             "IsFIUser": false,
             "AddressDetails": {
               "AddressLine1": "22",

--- a/test/connectors/FinancialInstitutionsConnectorSpec.scala
+++ b/test/connectors/FinancialInstitutionsConnectorSpec.scala
@@ -20,11 +20,9 @@ import base.SpecBase
 import generators.Generators
 import helpers.WireMockServerHandler
 import models.FinancialInstitutions.{AddressDetails, ContactDetails, CreateFIDetails, RemoveFIDetail}
-import org.apache.pekko.http.scaladsl.model.HttpResponse
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.Application
 import play.api.http.Status.{OK, SERVICE_UNAVAILABLE}
-import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -45,6 +43,7 @@ class FinancialInstitutionsConnectorSpec extends SpecBase with WireMockServerHan
     FIName = "financial-institution",
     SubscriptionID = "XE512345678",
     TINDetails = Seq.empty,
+    GIIN = None,
     IsFIUser = true,
     AddressDetails = AddressDetails(
       AddressLine1 = "line 1",

--- a/test/services/FinancialInstitutionUpdateServiceSpec.scala
+++ b/test/services/FinancialInstitutionUpdateServiceSpec.scala
@@ -280,7 +280,7 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
         forAll {
           fiDetails: FIDetail =>
             val fiDetailsGIIN     = GIINumber(UUID.randomUUID().toString)
-            val fiDetailsWithGIIN = fiDetails.copy(TINDetails = Seq(TINDetails(TINType = GIIN, TIN = fiDetailsGIIN.value, "")))
+            val fiDetailsWithGIIN = fiDetails.copy(TINDetails = Seq(TINDetails(TINType = UTR, TIN = fiDetailsGIIN.value, "")))
             when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
             when(mockCountryListFactory.findCountryWithCode(any())).thenReturn(Option(Country.GB))
             when(mockCountryListFactory.countryCodesForUkCountries).thenReturn(fiDetails.AddressDetails.CountryCode.toSet)
@@ -536,12 +536,6 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
     populatedUserAnswers.get(WhichIdentificationNumbersPage) contains TRN
     populatedUserAnswers.get(TrustURNPage) mustBe maybeTRN.map(
       id => TrustUniqueReferenceNumber(id.TIN)
-    )
-
-    val maybeGIIN = fiDetails.TINDetails.find(_.TINType == GIIN)
-    populatedUserAnswers.get(HaveGIINPage).value mustBe maybeGIIN.isDefined
-    populatedUserAnswers.get(WhatIsGIINPage) mustBe maybeGIIN.map(
-      id => GIINumber(id.TIN)
     )
   }
 


### PR DESCRIPTION
Simplify GIIN handling by decoupling it from TINDetails and introducing a dedicated field in FIDetail. This improves clarity, reduces complexity, and removes redundant checks for GIIN in TINType workflows.