### PR TITLE
DAC6-3633: Rename TRN to TURN

### DIFF
--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -17,7 +17,7 @@
 package forms.mappings
 
 import models.FinancialInstitutions.TINType
-import models.FinancialInstitutions.TINType.TRN
+import models.FinancialInstitutions.TINType.TURN
 import play.api.data.validation.{Constraint, Invalid, Valid}
 
 import java.time.LocalDate
@@ -111,8 +111,8 @@ trait Constraints {
 
   protected def noMixedTrn(errorKey: String): Constraint[Set[TINType]] =
     Constraint {
-      case set if !(set.contains(TRN) && set.size > 1) => Valid
-      case _                                           => Invalid(errorKey)
+      case set if !(set.contains(TURN) && set.size > 1) => Valid
+      case _                                            => Invalid(errorKey)
     }
 
 }

--- a/app/models/FinancialInstitutions/TINType.scala
+++ b/app/models/FinancialInstitutions/TINType.scala
@@ -28,19 +28,19 @@ object TINType extends Enumerable.Implicits {
 
   case object UTR extends TINType
   case object CRN extends TINType
-  case object TRN extends TINType
+  case object TURN extends TINType
 
-  val allValues: IndexedSeq[TINType]     = IndexedSeq(UTR, CRN, TRN)
-  val whichIdValues: IndexedSeq[TINType] = IndexedSeq(UTR, CRN, TRN)
+  val allValues: IndexedSeq[TINType]     = IndexedSeq(UTR, CRN, TURN)
+  val whichIdValues: IndexedSeq[TINType] = IndexedSeq(UTR, CRN, TURN)
 
   def checkboxItems(implicit messages: Messages): Seq[CheckboxItem] = {
     val items = whichIdValues.zipWithIndex.map {
-      case (TRN, index) =>
+      case (TURN, index) =>
         CheckboxItemViewModel(
-          content = Text(messages(s"whichIdentificationNumbers.${TRN.toString}")),
+          content = Text(messages(s"whichIdentificationNumbers.${TURN.toString}")),
           fieldId = "value",
           index = index,
-          value = TRN.toString
+          value = TURN.toString
         ).withAttribute(("data-behaviour", "exclusive"))
       case (value, index) =>
         CheckboxItemViewModel(

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -290,10 +290,10 @@ class Navigator @Inject() () {
 
   private def whichIdPage(ua: UserAnswers): Call =
     ua.get(WhichIdentificationNumbersPage).fold(controllers.routes.JourneyRecoveryController.onPageLoad()) {
-      case set if set.contains(UTR) => routes.WhatIsUniqueTaxpayerReferenceController.onPageLoad(NormalMode)
-      case set if set.contains(CRN) => routes.WhatIsCompanyRegistrationNumberController.onPageLoad(NormalMode)
-      case set if set.contains(TRN) => routes.TrustURNController.onPageLoad(NormalMode)
-      case _                        => controllers.routes.JourneyRecoveryController.onPageLoad()
+      case set if set.contains(UTR)  => routes.WhatIsUniqueTaxpayerReferenceController.onPageLoad(NormalMode)
+      case set if set.contains(CRN)  => routes.WhatIsCompanyRegistrationNumberController.onPageLoad(NormalMode)
+      case set if set.contains(TURN) => routes.TrustURNController.onPageLoad(NormalMode)
+      case _                         => controllers.routes.JourneyRecoveryController.onPageLoad()
     }
 
   private def changeWhichIdPage(ua: UserAnswers): Call = {
@@ -314,7 +314,7 @@ class Navigator @Inject() () {
           routes.WhatIsUniqueTaxpayerReferenceController.onPageLoad(CheckMode)
         case CRN if isMissing(CompanyRegistrationNumberPage) =>
           routes.WhatIsCompanyRegistrationNumberController.onPageLoad(CheckMode)
-        case TRN if isMissing(TrustURNPage) =>
+        case TURN if isMissing(TrustURNPage) =>
           routes.TrustURNController.onPageLoad(CheckMode)
       }
 

--- a/app/pages/addFinancialInstitution/WhichIdentificationNumbersPage.scala
+++ b/app/pages/addFinancialInstitution/WhichIdentificationNumbersPage.scala
@@ -31,9 +31,9 @@ case object WhichIdentificationNumbersPage extends QuestionPage[Set[TINType]] {
 
   def cleanUpUnselectedTINPages(selectedTINs: Set[TINType], userAnswers: UserAnswers): Try[UserAnswers] = {
     val tinPages = Seq(
-      TINType.UTR -> WhatIsUniqueTaxpayerReferencePage,
-      TINType.CRN -> CompanyRegistrationNumberPage,
-      TINType.TRN -> TrustURNPage
+      TINType.UTR  -> WhatIsUniqueTaxpayerReferencePage,
+      TINType.CRN  -> CompanyRegistrationNumberPage,
+      TINType.TURN -> TrustURNPage
     ).collect {
       case (tin, page) if !selectedTINs.contains(tin) => page
     }

--- a/app/services/FinancialInstitutionUpdateService.scala
+++ b/app/services/FinancialInstitutionUpdateService.scala
@@ -119,10 +119,10 @@ class FinancialInstitutionUpdateService @Inject() (
                     .set(WhichIdentificationNumbersPage, answers.get(WhichIdentificationNumbersPage).getOrElse(Set.empty) + TINType.CRN, cleanup = false)
                     .flatMap(_.set(CompanyRegistrationNumberPage, CompanyRegistrationNumber(details.TIN), cleanup = false))
                 )
-              case TRN =>
+              case TURN =>
                 Future.fromTry(
                   answers
-                    .set(WhichIdentificationNumbersPage, answers.get(WhichIdentificationNumbersPage).getOrElse(Set.empty) + TINType.TRN, cleanup = false)
+                    .set(WhichIdentificationNumbersPage, answers.get(WhichIdentificationNumbersPage).getOrElse(Set.empty) + TINType.TURN, cleanup = false)
                     .flatMap(_.set(TrustURNPage, TrustUniqueReferenceNumber(details.TIN), cleanup = false))
                 )
               case _ =>
@@ -243,7 +243,7 @@ class FinancialInstitutionUpdateService @Inject() (
 
   def checkTRNforChange(userAnswers: UserAnswers, tinDetails: Seq[TINDetails]): Boolean = {
     val uaValue: Option[String]     = userAnswers.get(TrustURNPage).map(_.value)
-    val detailValue: Option[String] = tinDetails.find(_.TINType == TRN).map(_.TIN)
+    val detailValue: Option[String] = tinDetails.find(_.TINType == TURN).map(_.TIN)
     uaValue != detailValue
   }
 
@@ -263,10 +263,10 @@ class FinancialInstitutionUpdateService @Inject() (
       detailTinTypes.toSeq.exists {
         tinType =>
           tinType match {
-            case TINType.UTR => checkUTRforChange(userAnswers, tinDetails)
-            case TINType.CRN => checkCRNforChange(userAnswers, tinDetails)
-            case TINType.TRN => checkTRNforChange(userAnswers, tinDetails)
-            case _           => false
+            case TINType.UTR  => checkUTRforChange(userAnswers, tinDetails)
+            case TINType.CRN  => checkCRNforChange(userAnswers, tinDetails)
+            case TINType.TURN => checkTRNforChange(userAnswers, tinDetails)
+            case _            => false
           }
       }
     } else {

--- a/app/services/FinancialInstitutionsService.scala
+++ b/app/services/FinancialInstitutionsService.scala
@@ -17,7 +17,7 @@
 package services
 
 import connectors.FinancialInstitutionsConnector
-import models.FinancialInstitutions.TINType.{CRN, TRN, UTR}
+import models.FinancialInstitutions.TINType.{CRN, TURN, UTR}
 import models.FinancialInstitutions._
 import models.UserAnswers
 import pages.addFinancialInstitution.IsRegisteredBusiness.{FetchedRegisteredAddressPage, ReportForRegisteredBusinessPage}
@@ -147,7 +147,7 @@ class FinancialInstitutionsService @Inject() (connector: FinancialInstitutionsCo
       case _         => Seq.empty
     }
     val trn = userAnswers.get(TrustURNPage) match {
-      case Some(trn) => Seq(TINDetails(TRN, trn.value, "GB"))
+      case Some(trn) => Seq(TINDetails(TURN, trn.value, "GB"))
       case _         => Seq.empty
     }
     utr ++ crn ++ trn

--- a/app/utils/CheckYourAnswersValidator.scala
+++ b/app/utils/CheckYourAnswersValidator.scala
@@ -115,7 +115,7 @@ sealed trait AddFIValidator {
             checkPage(CompanyRegistrationNumberPage).map(
               _ => CompanyRegistrationNumberPage
             )
-          case TINType.TRN =>
+          case TINType.TURN =>
             checkPage(TrustURNPage).map(
               _ => TrustURNPage
             )

--- a/app/viewmodels/common/package.scala
+++ b/app/viewmodels/common/package.scala
@@ -78,8 +78,8 @@ package object common {
       case Seq(TINType.CRN) => Seq(WhichIdentificationNumbersSummary.row(ua), CompanyRegistrationNumberSummary.row(ua)).flatten
       case Seq(TINType.UTR, TINType.CRN) =>
         Seq(WhichIdentificationNumbersSummary.row(ua), WhatIsUniqueTaxpayerReferenceSummary.row(ua, pageType), CompanyRegistrationNumberSummary.row(ua)).flatten
-      case Seq(TINType.TRN) => Seq(WhichIdentificationNumbersSummary.row(ua), TrustURNSummary.row(ua)).flatten
-      case _                => Seq.empty[SummaryListRow]
+      case Seq(TINType.TURN) => Seq(WhichIdentificationNumbersSummary.row(ua), TrustURNSummary.row(ua)).flatten
+      case _                 => Seq.empty[SummaryListRow]
     }
   }
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -432,11 +432,11 @@ whichIdentificationNumbers.heading = Which identification numbers can you provid
 whichIdentificationNumbers.hint = Select at least one option.
 whichIdentificationNumbers.UTR = Unique Taxpayer Reference (UTR)
 whichIdentificationNumbers.CRN = Company Registration Number (CRN)
-whichIdentificationNumbers.TRN = Trust Unique Reference Number (URN)
+whichIdentificationNumbers.TURN = Trust Unique Reference Number (URN)
 
 whichIdentificationNumbersSummary.UTR = Unique Taxpayer Reference
 whichIdentificationNumbersSummary.CRN = Company Registration Number
-whichIdentificationNumbersSummary.TRN = Trust Unique Reference Number
+whichIdentificationNumbersSummary.TURN = Trust Unique Reference Number
 
 whichIdentificationNumbers.or = or
 whichIdentificationNumbers.checkYourAnswersLabel = Which identification numbers can you provide for them?

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -127,7 +127,7 @@ trait ModelGenerators extends RegexConstants with Generators {
       fiId                    <- stringOfLength(15)
       fiName                  <- stringOfLength(105)
       subscriptionId          <- validSubscriptionID
-      tinType                 <- Gen.oneOf(TINType.UTR, TINType.CRN, TINType.TRN)
+      tinType                 <- Gen.oneOf(TINType.UTR, TINType.CRN, TINType.TURN)
       tin                     <- stringOfLength(10)
       tinDetails              <- Gen.const(List(TINDetails(tinType, tin, "GB")))
       giin                    <- Gen.option(stringOfLength(10))

--- a/test/navigation/CheckModeNavigatorSpec.scala
+++ b/test/navigation/CheckModeNavigatorSpec.scala
@@ -19,8 +19,8 @@ package navigation
 import base.SpecBase
 import controllers.addFinancialInstitution.routes
 import models.FinancialInstitutions.TINType
-import models.FinancialInstitutions.TINType.{CRN, TRN, UTR}
-import models.{CheckMode, _}
+import models.FinancialInstitutions.TINType.{CRN, TURN, UTR}
+import models._
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks.forAll
 import pages._
@@ -85,14 +85,14 @@ class CheckModeNavigatorSpec extends SpecBase {
         "with TRN selected" - {
           "to CheckAnswers if TrustURNPage is populated" in {
             val userAnswers = emptyUserAnswers
-              .withPage(WhichIdentificationNumbersPage, Set(TRN: TINType))
+              .withPage(WhichIdentificationNumbersPage, Set(TURN: TINType))
               .withPage(TrustURNPage, TrustUniqueReferenceNumber("someTRN"))
             navigator.nextPage(WhichIdentificationNumbersPage, CheckMode, userAnswers) mustBe
               controllers.addFinancialInstitution.routes.CheckYourAnswersController.onPageLoad()
           }
           "to TrustURN if TrustURNPage is not populated" in {
             val userAnswers = emptyUserAnswers
-              .withPage(WhichIdentificationNumbersPage, Set(TRN: TINType))
+              .withPage(WhichIdentificationNumbersPage, Set(TURN: TINType))
             navigator.nextPage(WhichIdentificationNumbersPage, CheckMode, userAnswers) mustBe
               controllers.addFinancialInstitution.routes.TrustURNController.onPageLoad(CheckMode)
           }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -141,7 +141,7 @@ class NavigatorSpec extends SpecBase {
             routes.WhatIsCompanyRegistrationNumberController.onPageLoad(NormalMode)
         }
         "to TrustURN page when TRN selected" in {
-          val userAnswers = emptyUserAnswers.withPage(WhichIdentificationNumbersPage, Set(TRN: TINType))
+          val userAnswers = emptyUserAnswers.withPage(WhichIdentificationNumbersPage, Set(TURN: TINType))
           navigator.nextPage(WhichIdentificationNumbersPage, NormalMode, userAnswers) mustBe
             routes.TrustURNController.onPageLoad(NormalMode)
         }

--- a/test/pages/addFinancialInstitution/WhichIdentificationNumbersPageSpec.scala
+++ b/test/pages/addFinancialInstitution/WhichIdentificationNumbersPageSpec.scala
@@ -72,7 +72,7 @@ class WhichIdentificationNumbersPageSpec extends PageBehaviours {
         .withPage(CompanyRegistrationNumberPage, CompanyRegistrationNumber("test"))
         .withPage(TrustURNPage, TrustUniqueReferenceNumber("someTRN"))
 
-      val selectedTINs: Set[TINType] = Set(TINType.TRN)
+      val selectedTINs: Set[TINType] = Set(TINType.TURN)
       val result                     = WhichIdentificationNumbersPage.cleanUpUnselectedTINPages(selectedTINs, userAnswers).success.value
 
       result.get(WhatIsUniqueTaxpayerReferencePage) mustBe empty

--- a/test/services/FinancialInstitutionUpdateServiceSpec.scala
+++ b/test/services/FinancialInstitutionUpdateServiceSpec.scala
@@ -532,8 +532,8 @@ class FinancialInstitutionUpdateServiceSpec extends SpecBase with MockitoSugar w
       id => CompanyRegistrationNumber(id.TIN)
     )
 
-    val maybeTRN: Option[TINDetails] = fiDetails.TINDetails.find(_.TINType == TRN)
-    populatedUserAnswers.get(WhichIdentificationNumbersPage) contains TRN
+    val maybeTRN: Option[TINDetails] = fiDetails.TINDetails.find(_.TINType == TURN)
+    populatedUserAnswers.get(WhichIdentificationNumbersPage) contains TURN
     populatedUserAnswers.get(TrustURNPage) mustBe maybeTRN.map(
       id => TrustUniqueReferenceNumber(id.TIN)
     )

--- a/test/viewmodels/checkAnswers/CheckYourAnswersViewModelSpec.scala
+++ b/test/viewmodels/checkAnswers/CheckYourAnswersViewModelSpec.scala
@@ -56,7 +56,7 @@ class CheckYourAnswersViewModelSpec extends SpecBase {
           .withPage(WhatIsUniqueTaxpayerReferencePage, UniqueTaxpayerReference("test"))
           .withPage(CompanyRegistrationNumberPage, CompanyRegistrationNumber("test"))
         val ua3 = ua
-          .withPage(WhichIdentificationNumbersPage, Set(TRN: TINType))
+          .withPage(WhichIdentificationNumbersPage, Set(TURN: TINType))
           .withPage(TrustURNPage, TrustUniqueReferenceNumber("test"))
 
         sut.getFinancialInstitutionSummaries(ua1).length mustBe 2


### PR DESCRIPTION
Renamed all instances of 'TRN' to 'TURN' in TINType and related logic to improve consistency and clarity. Updated affected navigation, validation, and test cases to reflect the changes.