### PR TITLE
DAC6-3786: Make `addressLine3` optional

### DIFF
--- a/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
+++ b/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
@@ -53,7 +53,7 @@ class CheckYourAnswersController @Inject() (
     implicit request =>
       val ua: UserAnswers          = request.userAnswers
       val fiName                   = getFinancialInstitutionName(ua)
-      val financialInstitutionList = SummaryListViewModel(getFinancialInstitutionSummaries(ua)).withCssClass("govuk-summary-list--no-border")
+      val financialInstitutionList = SummaryListViewModel(getFinancialInstitutionSummaries(ua))
       val firstContactList         = SummaryListViewModel(getFirstContactSummaries(ua, CheckAnswers))
       val secondContactList        = SummaryListViewModel(getSecondContactSummaries(ua, CheckAnswers))
 

--- a/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
+++ b/app/controllers/addFinancialInstitution/CheckYourAnswersController.scala
@@ -53,7 +53,7 @@ class CheckYourAnswersController @Inject() (
     implicit request =>
       val ua: UserAnswers          = request.userAnswers
       val fiName                   = getFinancialInstitutionName(ua)
-      val financialInstitutionList = SummaryListViewModel(getFinancialInstitutionSummaries(ua))
+      val financialInstitutionList = SummaryListViewModel(getFinancialInstitutionSummaries(ua)).withCssClass("govuk-summary-list--no-border")
       val firstContactList         = SummaryListViewModel(getFirstContactSummaries(ua, CheckAnswers))
       val secondContactList        = SummaryListViewModel(getSecondContactSummaries(ua, CheckAnswers))
 

--- a/app/forms/addFinancialInstitution/NonUkAddressFormProvider.scala
+++ b/app/forms/addFinancialInstitution/NonUkAddressFormProvider.scala
@@ -42,8 +42,7 @@ class NonUkAddressFormProvider @Inject() extends Mappings with RegexConstants {
         apiAddressRegex,
         addressLineLength
       ),
-      "addressLine3" -> validatedText(
-        "nonUkAddress.error.addressLine3.required",
+      "addressLine3" -> validatedOptionalText(
         "nonUkAddress.error.addressLine3.invalid",
         "nonUkAddress.error.addressLine3.length",
         apiAddressRegex,

--- a/app/forms/addFinancialInstitution/UkAddressFormProvider.scala
+++ b/app/forms/addFinancialInstitution/UkAddressFormProvider.scala
@@ -40,8 +40,7 @@ class UkAddressFormProvider extends Mappings with RegexConstants {
                                               apiAddressRegex,
                                               addressLineLength
       ),
-      "addressLine3" -> validatedText(
-        "ukAddress.error.addressLine3.required",
+      "addressLine3" -> validatedOptionalText(
         "ukAddress.error.addressLine3.invalid",
         "ukAddress.error.addressLine3.length",
         apiAddressRegex,

--- a/app/models/Address.scala
+++ b/app/models/Address.scala
@@ -21,7 +21,7 @@ import play.api.libs.json._
 case class Address(
   addressLine1: String,
   addressLine2: Option[String],
-  addressLine3: String,
+  addressLine3: Option[String],
   addressLine4: Option[String],
   postCode: Option[String],
   country: Country
@@ -30,7 +30,7 @@ case class Address(
   def lines: Seq[String] = Seq(
     Some(addressLine1),
     addressLine2,
-    Some(addressLine3),
+    addressLine3,
     addressLine4,
     postCode,
     Some(country.description)
@@ -39,7 +39,7 @@ case class Address(
   def linesWithoutCountry: Seq[String] = Seq(
     Some(addressLine1),
     addressLine2,
-    Some(addressLine3),
+    addressLine3,
     addressLine4,
     postCode
   ).flatten

--- a/app/models/AddressLookup.scala
+++ b/app/models/AddressLookup.scala
@@ -44,7 +44,7 @@ case class AddressLookup(addressLine1: Option[String],
     }
     val safePostcode = Option(postcode)
 
-    Address(line1, line2, line3, line4, safePostcode, country.getOrElse(Country.GB))
+    Address(line1, line2, Some(line3), line4, safePostcode, country.getOrElse(Country.GB))
   }
 
 }

--- a/app/models/AddressResponse.scala
+++ b/app/models/AddressResponse.scala
@@ -32,7 +32,7 @@ case class AddressResponse(
 
     val line1        = addressLine1
     val line2        = addressLine2
-    val line3        = addressLine3.getOrElse("")
+    val line3        = addressLine3
     val line4        = addressLine4
     val safePostcode = postalCode
 

--- a/app/models/FinancialInstitutions/FIDetail.scala
+++ b/app/models/FinancialInstitutions/FIDetail.scala
@@ -85,7 +85,7 @@ object AddressDetails {
 final case class AddressDetails(
   AddressLine1: String,
   AddressLine2: Option[String],
-  AddressLine3: String,
+  AddressLine3: Option[String],
   AddressLine4: Option[String],
   CountryCode: Option[String],
   PostalCode: Option[String]

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.1.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.6.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -50,7 +50,7 @@ trait ModelGenerators extends RegexConstants with Generators {
       for {
         addressLine1 <- nonEmptyString
         addressLine2 <- Gen.option(nonEmptyString)
-        addressLine3 <- nonEmptyString
+        addressLine3 <- Gen.option(nonEmptyString)
         addressLine4 <- Gen.option(nonEmptyString)
         postCode     <- Gen.option(nonEmptyString)
         country      <- arbitrary[Country]
@@ -90,7 +90,7 @@ trait ModelGenerators extends RegexConstants with Generators {
     for {
       addressLine1 <- stringOfLength(35)
       addressLine2 <- Gen.option(stringOfLength(35))
-      addressLine3 <- stringOfLength(35)
+      addressLine3 <- Gen.option(stringOfLength(35))
       addressLine4 <- Gen.option(stringOfLength(35))
       postalCode   <- Gen.option(validPostCodes)
       countryCode  <- stringOfLength(2)

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -103,7 +103,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
       List(),
       Some("689355555"),
       IsFIUser = true,
-      AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
+      AddressDetails("22", Some("High Street"), Some("Dawley"), Some("Dawley"), Some("GB"), Some("TF22 2RE")),
       Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
       Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
     )
@@ -117,7 +117,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         List(),
         Some("689355555"),
         IsFIUser = true,
-        AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
+        AddressDetails("22", Some("High Street"), Some("Dawley"), Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Jane Doe", "janedoe@example.com", Some("0444458888"))),
         Some(ContactDetails("John Doe", "johndoe@example.com", Some("0333458888")))
       ),
@@ -128,7 +128,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
         List(),
         Some("689344444"),
         IsFIUser = false,
-        AddressDetails("22", Some("High Street"), "Dawley", Some("Dawley"), Some("GB"), Some("TF22 2RE")),
+        AddressDetails("22", Some("High Street"), Some("Dawley"), Some("Dawley"), Some("GB"), Some("TF22 2RE")),
         Some(ContactDetails("Foo Bar", "fbar@example.com", Some("0223458888"))),
         Some(ContactDetails("Foobar Baz", "fbaz@example.com", Some("0123456789")))
       )
@@ -206,7 +206,7 @@ trait SpecBase extends AnyFreeSpec with Matchers with TryValues with OptionValue
       |}
       |""".stripMargin
 
-  val testAddress: Address                 = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
+  val testAddress: Address                 = Address("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB)
   val testAddressResponse: AddressResponse = AddressResponse("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB.code)
 
   val testNonUKAddressResponse: AddressResponse =

--- a/test/connectors/FinancialInstitutionsConnectorSpec.scala
+++ b/test/connectors/FinancialInstitutionsConnectorSpec.scala
@@ -48,7 +48,7 @@ class FinancialInstitutionsConnectorSpec extends SpecBase with WireMockServerHan
     AddressDetails = AddressDetails(
       AddressLine1 = "line 1",
       AddressLine2 = None,
-      AddressLine3 = "line 3",
+      AddressLine3 = Some("line 3"),
       AddressLine4 = None,
       CountryCode = Some("GB"),
       PostalCode = Some("AA1 1AA")

--- a/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/IsThisAddressControllerSpec.scala
@@ -44,7 +44,7 @@ class IsThisAddressControllerSpec extends SpecBase with MockitoSugar {
   val address: Address = Address(
     "1 address street",
     addressLine2 = None,
-    addressLine3 = "Address town",
+    addressLine3 = Some("Address town"),
     addressLine4 = Some("Wessex"),
     postCode = Some("postcode"),
     country = Country.GB

--- a/test/controllers/addFinancialInstitution/UkAddressControllerSpec.scala
+++ b/test/controllers/addFinancialInstitution/UkAddressControllerSpec.scala
@@ -38,7 +38,7 @@ class UkAddressControllerSpec extends SpecBase with GuiceOneAppPerSuite with Moc
 
   private def onwardRoute = Call("GET", "/foo")
 
-  private val address: Address = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
+  private val address: Address = Address("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB)
 
   private val formProvider = new UkAddressFormProvider()
   private val form         = formProvider()

--- a/test/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionControllerSpec.scala
+++ b/test/controllers/changeFinancialInstitution/ChangeRegisteredFinancialInstitutionControllerSpec.scala
@@ -64,7 +64,7 @@ class ChangeRegisteredFinancialInstitutionControllerSpec
   val mockCtUtrRetrievalAction: CtUtrRetrievalAction = mock[CtUtrRetrievalAction]
   private val mockFinancialInstitutionsService       = mock[FinancialInstitutionsService]
   private val mockFinancialInstitutionUpdateService  = mock[FinancialInstitutionUpdateService]
-  private val address: Address                       = Address("value 1", Some("value 2"), "value 3", Some("value 4"), Some("XX9 9XX"), Country.GB)
+  private val address: Address                       = Address("value 1", Some("value 2"), Some("value 3"), Some("value 4"), Some("XX9 9XX"), Country.GB)
 
   when(mockCtUtrRetrievalAction.apply()).thenReturn(new FakeCtUtrRetrievalAction())
 

--- a/test/forms/addFinancialInstitution/NonUkAddressFormProviderSpec.scala
+++ b/test/forms/addFinancialInstitution/NonUkAddressFormProviderSpec.scala
@@ -107,10 +107,9 @@ class NonUkAddressFormProviderSpec extends StringFieldBehaviours {
 
   ".addressLine3" - {
 
-    val fieldName   = "addressLine3"
-    val requiredKey = "nonUkAddress.error.addressLine3.required"
-    val invalidKey  = "nonUkAddress.error.addressLine3.invalid"
-    val lengthKey   = "nonUkAddress.error.addressLine3.length"
+    val fieldName  = "addressLine3"
+    val invalidKey = "nonUkAddress.error.addressLine3.invalid"
+    val lengthKey  = "nonUkAddress.error.addressLine3.length"
 
     behave like fieldThatBindsValidDataWithoutInvalidError(
       form,
@@ -124,18 +123,6 @@ class NonUkAddressFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = addressLineMaxLength,
       lengthError = FormError(fieldName, lengthKey)
-    )
-
-    behave like fieldWithNonEmptyWhitespace(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
-
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
     )
 
     behave like fieldWithInvalidData(

--- a/test/forms/addFinancialInstitution/UkAddressFormProviderSpec.scala
+++ b/test/forms/addFinancialInstitution/UkAddressFormProviderSpec.scala
@@ -97,9 +97,9 @@ class UkAddressFormProviderSpec extends StringFieldBehaviours {
 
   ".addressLine3" - {
 
-    val fieldName   = "addressLine3"
-    val invalidKey  = "ukAddress.error.addressLine3.invalid"
-    val lengthKey   = "ukAddress.error.addressLine3.length"
+    val fieldName  = "addressLine3"
+    val invalidKey = "ukAddress.error.addressLine3.invalid"
+    val lengthKey  = "ukAddress.error.addressLine3.length"
 
     behave like fieldThatBindsValidDataWithoutInvalidError(
       form,

--- a/test/forms/addFinancialInstitution/UkAddressFormProviderSpec.scala
+++ b/test/forms/addFinancialInstitution/UkAddressFormProviderSpec.scala
@@ -98,7 +98,6 @@ class UkAddressFormProviderSpec extends StringFieldBehaviours {
   ".addressLine3" - {
 
     val fieldName   = "addressLine3"
-    val requiredKey = "ukAddress.error.addressLine3.required"
     val invalidKey  = "ukAddress.error.addressLine3.invalid"
     val lengthKey   = "ukAddress.error.addressLine3.length"
 
@@ -114,18 +113,6 @@ class UkAddressFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       maxLength = addressLineMaxLength,
       lengthError = FormError(fieldName, lengthKey)
-    )
-
-    behave like fieldWithNonEmptyWhitespace(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
-    )
-
-    behave like mandatoryField(
-      form,
-      fieldName,
-      requiredError = FormError(fieldName, requiredKey)
     )
 
     behave like fieldWithInvalidData(

--- a/test/utils/AddressHelperSpec.scala
+++ b/test/utils/AddressHelperSpec.scala
@@ -25,12 +25,12 @@ class AddressHelperSpec extends SpecBase {
 
   "formatAddress" - {
     "format Address correctly" in {
-      val address = Address("line1", Some("line2"), "line3", Some("line4"), Some("postcode"), Country.GB)
+      val address = Address("line1", Some("line2"), Some("line3"), Some("line4"), Some("postcode"), Country.GB)
       val result  = sut.formatAddress(address)
       result mustBe "line1, line2, line3, line4, postcode, United Kingdom"
     }
     "format Address correctly as html" in {
-      val address = Address("line1", Some("line2"), "line3", Some("line4"), Some("postcode"), Country.GB)
+      val address = Address("line1", Some("line2"), Some("line3"), Some("line4"), Some("postcode"), Country.GB)
       val expectedResult = HtmlContent(
         """|<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>line1</p>
            |<p class='govuk-!-margin-top-0 govuk-!-margin-bottom-0'>line2</p>
@@ -85,23 +85,23 @@ class AddressHelperSpec extends SpecBase {
   "AddressLookup" - {
     "toAddress must convert to Address class" in {
       val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
-      val expectedAddress = Address("line1", Some("line2"), "line3", Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
+      val expectedAddress = Address("line1", Some("line2"), Some("line3"), Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
     }
     "toAddress must populate from the town field correctly without line3" in {
       val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, Some("line4"), "town", Some("county"), "postcode", Some(Country.GB))
-      val expectedAddress = Address("line1", Some("line2"), "town", Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
+      val expectedAddress = Address("line1", Some("line2"), Some("town"), Some("line4"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
     }
     "toAddress must populate from the town field correctly without line4" in {
       val addressLookup   = AddressLookup(Some("line1"), Some("line2"), Some("line3"), None, "town", Some("county"), "postcode", Some(Country.GB))
-      val expectedAddress = Address("line1", Some("line2"), "line3", Some("town"), Some("postcode"), Country("", "GB", "United Kingdom"))
+      val expectedAddress = Address("line1", Some("line2"), Some("line3"), Some("town"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
 
     }
     "toAddress must populate county field if there is space" in {
       val addressLookup   = AddressLookup(Some("line1"), Some("line2"), None, None, "town", Some("county"), "postcode", Some(Country.GB))
-      val expectedAddress = Address("line1", Some("line2"), "town", Some("county"), Some("postcode"), Country("", "GB", "United Kingdom"))
+      val expectedAddress = Address("line1", Some("line2"), Some("town"), Some("county"), Some("postcode"), Country("", "GB", "United Kingdom"))
       addressLookup.toAddress mustBe expectedAddress
 
     }


### PR DESCRIPTION
Updated `Address` and related classes to make `addressLine3` optional. Adjusted forms, views, and tests to accommodate this change and ensure compatibility across the application.