### PR TITLE
DAC6-3814: Fix YourFinancialInstitutionsView

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,31 +8,6 @@
     word-break: break-word;
 }
 
-// These are for the specific behavior of the table on /your-fis
-.user-financial-institutions-summary .govuk-summary-list {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-}
-
-.user-financial-institutions-summary .govuk-summary-list__row {
-    display: flex;
-    align-items: top;
-    width: 100%;
-}
-
-.user-financial-institutions-summary .govuk-summary-list__actions {
-    flex: 0.5;
-}
-
-.user-financial-institutions-summary .govuk-summary-list__value {
-    line-height: 1.3157894737;
-    flex: 1;
-    overflow-wrap: break-word;
-    min-width: 0;
-}
-
-
 
 // Raise index of dropdown arrow on accessible autocomplete
 // This prevents it from being hidden behind the other address inputs

--- a/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
+++ b/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
@@ -19,11 +19,10 @@ package viewmodels.yourFinancialInstitutions
 import models.FinancialInstitutions.FIDetail
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.Value
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Empty, HtmlContent}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
 import viewmodels.common.accessibleActionItem
 import viewmodels.govuk.all.{FluentActionItem, SummaryListRowViewModel}
-import viewmodels.implicits._
 
 object YourFinancialInstitutionsViewModel {
 
@@ -32,8 +31,8 @@ object YourFinancialInstitutionsViewModel {
     orderedInstitutions.map {
       institution =>
         SummaryListRowViewModel(
-          key = Key("", "govuk-!-display-none"),
-          value = Value(getValueContent(institution.FIName, institution.IsFIUser)),
+          key = Key(getValueContent(institution.FIName, institution.IsFIUser), "govuk-!-font-weight-regular"),
+          value = Value(Empty, "govuk-!-display-none"),
           actions = Seq(
             accessibleActionItem(
               "site.change",
@@ -55,9 +54,11 @@ object YourFinancialInstitutionsViewModel {
 
   private def getValueContent(name: String, fiIsRegisteredBusiness: Boolean): HtmlContent = {
     val registeredBusinessTag =
-      if (fiIsRegisteredBusiness)
+      if (fiIsRegisteredBusiness) {
         """<strong class="govuk-tag" style="max-width: 180px !important;">Registered business</strong>"""
-      else ""
+      } else {
+        ""
+      }
 
     HtmlContent(s"""
          |<span class="govuk-!-margin-right-2" style="max-width: 180px">$name</span>

--- a/app/views/YourFinancialInstitutionsView.scala.html
+++ b/app/views/YourFinancialInstitutionsView.scala.html
@@ -44,7 +44,7 @@
     }
 
     @if(institutions.rows.nonEmpty) {
-        <div class="user-financial-institutions-summary">
+        <div class="govuk-form-group">
             @govukSummaryList(institutions)
         </div>
     }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.13.0"
+  private val bootstrapVersion = "9.16.0"
   private val hmrcMongoVersion = "2.6.0"
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.6.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.7.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/test/views/YourFinancialInstitutionsViewSpec.scala
+++ b/test/views/YourFinancialInstitutionsViewSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.SpecBase
+import forms.addFinancialInstitution.YourFinancialInstitutionsFormProvider
+import models.FinancialInstitutions.{AddressDetails, FIDetail}
+import org.jsoup.Jsoup
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.i18n.{Lang, Messages}
+import play.api.mvc.{AnyContent, MessagesControllerComponents}
+import play.api.test.{FakeRequest, Injecting}
+import utils.ViewHelper
+import viewmodels.govuk.all.SummaryListViewModelNoMargin
+import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel
+import views.html.YourFinancialInstitutionsView
+
+class YourFinancialInstitutionsViewSpec extends SpecBase with GuiceOneAppPerSuite with Injecting with ViewHelper {
+
+  private val view                                = app.injector.instanceOf[YourFinancialInstitutionsView]
+  private val formProvider                        = new YourFinancialInstitutionsFormProvider()
+  private val form                                = formProvider()
+  private val messagesControllerComponentsForView = app.injector.instanceOf[MessagesControllerComponents]
+
+  implicit private val request: FakeRequest[AnyContent] = FakeRequest()
+  implicit private val messages: Messages               = messagesControllerComponentsForView.messagesApi.preferred(Seq(Lang("en")))
+
+  "YourFinancialInstitutionsView" - {
+    "should render page components" in {
+
+      val summaryListViewModel = SummaryListViewModelNoMargin(
+        YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows(
+          Seq(
+            FIDetail(
+              FIID = "12345",
+              FIName = "Test Financial Institution",
+              SubscriptionID = "sub12345",
+              TINDetails = Seq.empty,
+              GIIN = None,
+              IsFIUser = false,
+              AddressDetails = AddressDetails(
+                AddressLine1 = "123 Test Street",
+                AddressLine2 = Some("Test City"),
+                AddressLine3 = None,
+                AddressLine4 = None,
+                CountryCode = Some("GB"),
+                PostalCode = Some("AB12 3CD")
+              ),
+              PrimaryContactDetails = None,
+              SecondaryContactDetails = None
+            )
+          )
+        )
+      )
+
+      val renderedHtml = view(form, summaryListViewModel)
+
+      lazy val doc = Jsoup.parse(renderedHtml.body)
+
+      getWindowTitle(doc) must include("Manage your financial institutions")
+      getPageHeading(doc) mustEqual "You have added 1 financial institution"
+      doc.body.select("dt").text() must include("Test Financial Institution")
+    }
+  }
+
+}


### PR DESCRIPTION
Introduced `YourFinancialInstitutionsViewSpec` to validate rendering of key view components for financial institutions. Simplified view layout styling by removing redundant CSS and aligning summary list with GOV.UK design standards.