### PR TITLE
DAC6-3814: Refactor FI view to use HmrcListWithActions

### DIFF
--- a/app/controllers/YourFinancialInstitutionsController.scala
+++ b/app/controllers/YourFinancialInstitutionsController.scala
@@ -25,7 +25,6 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
 import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import viewmodels.govuk.all.{SummaryListViewModel, SummaryListViewModelNoMargin}
 import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows
 import views.html.YourFinancialInstitutionsView
 
@@ -71,7 +70,7 @@ class YourFinancialInstitutionsController @Inject() (
         answersWithoutRemoveFI <- Future.fromTry(request.userAnswers.remove(InstitutionDetail))
         answersWithoutChangeFI <- Future.fromTry(answersWithoutRemoveFI.remove(ChangeFiDetailsInProgressId))
         _                      <- sessionRepository.set(answersWithoutChangeFI)
-      } yield Ok(view(form, SummaryListViewModelNoMargin(getYourFinancialInstitutionsRows(institutions)), removedInstitutionName))
+      } yield Ok(view(form, getYourFinancialInstitutionsRows(institutions), removedInstitutionName))
   }
 
   def onSubmit(): Action[AnyContent] = (identify andThen getData andThen requireData).async {
@@ -81,7 +80,7 @@ class YourFinancialInstitutionsController @Inject() (
         .fold(
           formWithErrors =>
             financialInstitutionsService.getListOfFinancialInstitutions(request.fatcaId) map {
-              institutions => Ok(view(formWithErrors, SummaryListViewModel(getYourFinancialInstitutionsRows(institutions))))
+              institutions => Ok(view(formWithErrors, getYourFinancialInstitutionsRows(institutions)))
             },
           {
             case true =>

--- a/app/viewmodels/common/package.scala
+++ b/app/viewmodels/common/package.scala
@@ -24,6 +24,7 @@ import pages.addFinancialInstitution.{HaveGIINPage, WhichIdentificationNumbersPa
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{ActionItem, SummaryListRow}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.ListWithActionsAction
 import viewmodels.checkAnswers._
 import viewmodels.govuk.summarylist._
 
@@ -38,6 +39,16 @@ package object common {
 
   def accessibleActionItem(messageKey: String, href: String)(implicit messages: Messages): ActionItem =
     ActionItemViewModel(
+      content = HtmlContent(
+        s"""
+           |<span aria-hidden="true">${messages(messageKey)}</span>
+           |""".stripMargin
+      ),
+      href = href
+    )
+
+  def accessibleListActionItem(messageKey: String, href: String)(implicit messages: Messages): ListWithActionsAction =
+    ListWithActionsAction(
       content = HtmlContent(
         s"""
            |<span aria-hidden="true">${messages(messageKey)}</span>

--- a/app/viewmodels/govuk/SummaryListFluency.scala
+++ b/app/viewmodels/govuk/SummaryListFluency.scala
@@ -18,6 +18,7 @@ package viewmodels.govuk
 
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.ListWithActionsAction
 
 object summarylist extends SummaryListFluency
 
@@ -91,6 +92,13 @@ trait SummaryListFluency {
         content = content,
         href = href
       )
+
+  }
+
+  implicit class FluentListActionItem(item: ListWithActionsAction) {
+
+    def withVisuallyHiddenText(text: String): ListWithActionsAction =
+      item.copy(visuallyHiddenText = Some(text))
 
   }
 

--- a/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
+++ b/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
@@ -18,23 +18,21 @@ package viewmodels.yourFinancialInstitutions
 
 import models.FinancialInstitutions.FIDetail
 import play.api.i18n.Messages
-import uk.gov.hmrc.govukfrontend.views.Aliases.Value
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Empty, HtmlContent}
-import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.{Key, SummaryListRow}
-import viewmodels.common.accessibleActionItem
-import viewmodels.govuk.all.{FluentActionItem, SummaryListRowViewModel}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.{ListWithActions, ListWithActionsItem}
+import viewmodels.common.accessibleListActionItem
+import viewmodels.govuk.all.FluentListActionItem
 
 object YourFinancialInstitutionsViewModel {
 
-  def getYourFinancialInstitutionsRows(institutions: Seq[FIDetail])(implicit messages: Messages): Seq[SummaryListRow] = {
+  def getYourFinancialInstitutionsRows(institutions: Seq[FIDetail])(implicit messages: Messages): ListWithActions = {
     val orderedInstitutions = orderInstitutions(institutions)
-    orderedInstitutions.map {
+    val items = orderedInstitutions.map {
       institution =>
-        SummaryListRowViewModel(
-          key = Key(getValueContent(institution.FIName, institution.IsFIUser), "govuk-!-font-weight-regular"),
-          value = Value(Empty, "govuk-!-display-none"),
+        ListWithActionsItem(
+          name = getValueContent(institution.FIName, institution.IsFIUser),
           actions = Seq(
-            accessibleActionItem(
+            accessibleListActionItem(
               "site.change",
               if (institution.IsFIUser) {
                 controllers.changeFinancialInstitution.routes.ChangeRegisteredFinancialInstitutionController.onPageLoad(institution.FIID).url
@@ -43,13 +41,14 @@ object YourFinancialInstitutionsViewModel {
               }
             )
               .withVisuallyHiddenText(messages("yourFinancialInstitutions.change.hidden", institution.FIName)),
-            accessibleActionItem("site.remove", controllers.routes.UserAccessController.onPageLoad(institution.FIID).url)
+            accessibleListActionItem("site.remove", controllers.routes.UserAccessController.onPageLoad(institution.FIID).url)
               .withVisuallyHiddenText(messages("yourFinancialInstitutions.remove.hidden", institution.FIName)),
-            accessibleActionItem("yourFinancialInstitutions.link.manageReports", controllers.routes.YourFinancialInstitutionsController.onPageLoad().url)
+            accessibleListActionItem("yourFinancialInstitutions.link.manageReports", controllers.routes.YourFinancialInstitutionsController.onPageLoad().url)
               .withVisuallyHiddenText(messages("yourFinancialInstitutions.manageReports.hidden", institution.FIName))
           )
         )
     }
+    ListWithActions(items = items)
   }
 
   private def getValueContent(name: String, fiIsRegisteredBusiness: Boolean): HtmlContent = {

--- a/app/views/YourFinancialInstitutionsView.scala.html
+++ b/app/views/YourFinancialInstitutionsView.scala.html
@@ -22,12 +22,12 @@
         govukErrorSummary: GovukErrorSummary,
         govukRadios: GovukRadios,
         govukButton: GovukButton,
-        govukSummaryList: GovukSummaryList,
+        hmrcListWithActions: HmrcListWithActions,
         heading: Heading,
         notification: Notification
 )
 
-@(form: Form[_], institutions: SummaryList, removedInstitutionName: Option[String] = None)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], institutions: ListWithActions, removedInstitutionName: Option[String] = None)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("yourFinancialInstitutions.title")), fullWidth = true) {
 
@@ -35,17 +35,17 @@
         @govukErrorSummary(ErrorSummaryViewModel(form))
     }
 
-    @if(institutions.rows.isEmpty) {
+    @if(institutions.items.isEmpty) {
         @heading(messages("yourFinancialInstitutions.heading.noFinancialInstitutions"))
-    } else if (institutions.rows.size == 1) {
+    } else if (institutions.items.size == 1) {
         @heading(messages("yourFinancialInstitutions.heading.singleFinancialInstitution"))
     } else {
-        @heading(messages("yourFinancialInstitutions.heading.multipleFinancialInstitutions", institutions.rows.size))
+        @heading(messages("yourFinancialInstitutions.heading.multipleFinancialInstitutions", institutions.items.size))
     }
 
-    @if(institutions.rows.nonEmpty) {
+    @if(institutions.items.nonEmpty) {
         <div class="govuk-form-group">
-            @govukSummaryList(institutions)
+            @hmrcListWithActions(institutions)
         </div>
     }
 
@@ -53,7 +53,7 @@
         @govukRadios(
             RadiosViewModel.yesNo(
                 field = form("value"),
-                legend = LegendViewModel(if (institutions.rows.isEmpty) {
+                legend = LegendViewModel(if (institutions.items.isEmpty) {
                     messages("yourFinancialInstitutions.addFinancialInstitution")
                 } else {
                     messages("yourFinancialInstitutions.addAnotherFinancialInstitution")

--- a/test/controllers/YourFinancialInstitutionsControllerSpec.scala
+++ b/test/controllers/YourFinancialInstitutionsControllerSpec.scala
@@ -26,8 +26,8 @@ import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
+import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.ListWithActions
 import uk.gov.hmrc.http.HeaderCarrier
-import viewmodels.govuk.all.SummaryListViewModel
 import views.html.YourFinancialInstitutionsView
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -59,7 +59,7 @@ class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar
         val view = application.injector.instanceOf[YourFinancialInstitutionsView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view(form, SummaryListViewModel(Seq.empty))(request, messages(application)).toString
+        contentAsString(result) mustEqual view(form, ListWithActions(Seq.empty))(request, messages(application)).toString
       }
     }
 

--- a/test/views/YourFinancialInstitutionsViewSpec.scala
+++ b/test/views/YourFinancialInstitutionsViewSpec.scala
@@ -25,7 +25,6 @@ import play.api.i18n.{Lang, Messages}
 import play.api.mvc.{AnyContent, MessagesControllerComponents}
 import play.api.test.{FakeRequest, Injecting}
 import utils.ViewHelper
-import viewmodels.govuk.all.SummaryListViewModelNoMargin
 import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel
 import views.html.YourFinancialInstitutionsView
 
@@ -42,7 +41,7 @@ class YourFinancialInstitutionsViewSpec extends SpecBase with GuiceOneAppPerSuit
   "YourFinancialInstitutionsView" - {
     "should render page components" in {
 
-      val summaryListViewModel = SummaryListViewModelNoMargin(
+      val summaryListViewModel =
         YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows(
           Seq(
             FIDetail(
@@ -65,7 +64,6 @@ class YourFinancialInstitutionsViewSpec extends SpecBase with GuiceOneAppPerSuit
             )
           )
         )
-      )
 
       val renderedHtml = view(form, summaryListViewModel)
 


### PR DESCRIPTION
Replaced deprecated `SummaryList` and `SummaryListViewModelNoMargin` with `HmrcListWithActions` for aligning with updated design patterns. Adjusted relevant view models, templates, and associated test cases to support the new implementation, simplifying the code and improving maintainability.