### PR TITLE
Adjust FI logic for CT UTR

### DIFF
--- a/test/controllers/YourFinancialInstitutionsControllerSpec.scala
+++ b/test/controllers/YourFinancialInstitutionsControllerSpec.scala
@@ -18,21 +18,25 @@ package controllers
 
 import base.SpecBase
 import forms.addFinancialInstitution.YourFinancialInstitutionsFormProvider
+import generators.ModelGenerators
+import models.FinancialInstitutions.FIDetail
 import models.UserAnswers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{FinancialInstitutionUpdateService, FinancialInstitutionsService}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.ListWithActions
 import uk.gov.hmrc.http.HeaderCarrier
+import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel
 import views.html.YourFinancialInstitutionsView
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar {
+class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar with ModelGenerators with ScalaCheckDrivenPropertyChecks {
 
   val formProvider = new YourFinancialInstitutionsFormProvider()
   val form         = formProvider()
@@ -60,6 +64,34 @@ class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar
 
         status(result) mustEqual OK
         contentAsString(result) mustEqual view(form, ListWithActions(Seq.empty))(request, messages(application)).toString
+      }
+    }
+
+    "must list FIs as non-registered for non-CT user" in {
+      forAll {
+        fiDetail: FIDetail =>
+          val mockFinancialInstitutionsService = mock[FinancialInstitutionsService]
+          when(mockFinancialInstitutionsService.getListOfFinancialInstitutions(any())(any[HeaderCarrier](), any[ExecutionContext]()))
+            .thenReturn(Future.successful(Seq(fiDetail)))
+
+          val application = applicationBuilder(userAnswers = Option(emptyUserAnswers))
+            .overrides(
+              bind[FinancialInstitutionsService].toInstance(mockFinancialInstitutionsService)
+            )
+            .build()
+
+          running(application) {
+            val request = FakeRequest(GET, routes.YourFinancialInstitutionsController.onPageLoad().url)
+
+            val result = route(application, request).value
+
+            val view = application.injector.instanceOf[YourFinancialInstitutionsView]
+
+            val institutions = YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows(Seq(fiDetail.copy(IsFIUser = false)))(messages(application))
+
+            status(result) mustEqual OK
+            contentAsString(result) mustEqual view(form, institutions)(request, messages(application)).toString
+          }
       }
     }
 


### PR DESCRIPTION
Updated `YourFinancialInstitutionsController` to include `CtUtrRetrievalAction` for retrieving Corporation Tax UTR during financial institutions processing. Modified institution details mapping and updated unit tests to ensure non-CT users are correctly handled.