### PR TITLE
 DAC6-3812 - Accessibility Audit: CRS/FATCA: Issue 9672: Validation does not accommodate spaces (P1)

### DIFF
--- a/app/forms/mappings/Transforms.scala
+++ b/app/forms/mappings/Transforms.scala
@@ -29,7 +29,7 @@ trait Transforms {
     } else { validPostCode.toUpperCase }
 
   protected def validGIINFormat(validGIIN: String): String =
-    validGIIN.toUpperCase
+    stripSpaces(validGIIN.toUpperCase)
 
   protected def minimiseSpace(value: String): String =
     value.replaceAll(" {2,}", " ")

--- a/test/forms/addFinancialInstitution/WhatIsGIINFormProviderSpec.scala
+++ b/test/forms/addFinancialInstitution/WhatIsGIINFormProviderSpec.scala
@@ -88,7 +88,6 @@ class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
       FormError(fieldName, invalidCharKey),
       Some("chars")
     )
-
   }
 
 }

--- a/test/forms/addFinancialInstitution/WhatIsGIINFormProviderSpec.scala
+++ b/test/forms/addFinancialInstitution/WhatIsGIINFormProviderSpec.scala
@@ -40,6 +40,12 @@ class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
       validGIIN
     )
 
+    behave like fieldThatBindsValidDataWithASpace(
+      form,
+      fieldName,
+      validGIIN
+    )
+
     behave like fieldWithMaxLengthAlpha(
       form,
       fieldName,
@@ -82,6 +88,7 @@ class WhatIsGIINFormProviderSpec extends StringFieldBehaviours {
       FormError(fieldName, invalidCharKey),
       Some("chars")
     )
+
   }
 
 }

--- a/test/forms/behaviours/FieldBehaviours.scala
+++ b/test/forms/behaviours/FieldBehaviours.scala
@@ -18,6 +18,7 @@ package forms.behaviours
 
 import forms.FormSpec
 import generators.Generators
+import models.GIINumber
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.data.{Form, FormError}
@@ -32,6 +33,18 @@ trait FieldBehaviours extends FormSpec with ScalaCheckPropertyChecks with Genera
           val result = form.bind(Map(fieldName -> dataItem)).apply(fieldName)
           result.value.value mustBe dataItem
           result.errors mustBe empty
+      }
+    }
+
+  def fieldThatBindsValidDataWithASpace(form: Form[_], fieldName: String, validDataGenerator: Gen[String]): Unit =
+    "bind valid data that has spaces" in {
+
+      forAll(validDataGenerator -> "validDataItem") {
+        dataItem: String =>
+          val input  = s" $dataItem "
+          val result = form.bindFromRequest(Map(fieldName -> Seq(input)))
+          result.errors mustBe empty
+          result.value.value mustBe GIINumber(dataItem.toUpperCase)
       }
     }
 


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DAC6-3812
1. Changed the app/forms/mappings/Transforms.scala to strip out empty spaces.
2. Updated unit tests