### PR TITLE
Dac6 4318

### DIFF
--- a/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
+++ b/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
@@ -21,6 +21,8 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.hmrcfrontend.views.viewmodels.listwithactions.{ListWithActions, ListWithActionsAction, ListWithActionsItem}
 
+import java.time.LocalDate
+
 object YourFinancialInstitutionsViewModel {
 
   def getYourFinancialInstitutionsRows(institutions: Seq[FIDetail], manageReportLink: String)(implicit messages: Messages): ListWithActions = {
@@ -54,8 +56,8 @@ object YourFinancialInstitutionsViewModel {
     }
     ListWithActions(items = items)
   }
-
-  private def createManageReportUrl(baseUrl: String, fiId: String, fiName: String) = s"$baseUrl?fiId=$fiId&fiName=$fiName"
+  private def latestFinancialYear = LocalDate.now().getYear - 1
+  private def createManageReportUrl(baseUrl: String, fiId: String, fiName: String) = s"$baseUrl?fiId=$fiId&year=$latestFinancialYear"
 
   private def getValueContent(name: String, fiIsRegisteredBusiness: Boolean): HtmlContent = {
     val registeredBusinessTag =

--- a/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
+++ b/app/viewmodels/yourFinancialInstitutions/YourFinancialInstitutionsViewModel.scala
@@ -47,7 +47,7 @@ object YourFinancialInstitutionsViewModel {
               Some(messages("yourFinancialInstitutions.remove.hidden", institution.FIName))
             ),
             ListWithActionsAction(
-              createManageReportUrl(manageReportLink, institution.FIID, institution.FIName),
+              createManageReportUrl(manageReportLink, institution.FIID),
               Text(messages("yourFinancialInstitutions.link.manageReports")),
               Some(messages("yourFinancialInstitutions.manageReports.hidden", institution.FIName))
             )
@@ -56,8 +56,9 @@ object YourFinancialInstitutionsViewModel {
     }
     ListWithActions(items = items)
   }
-  private def latestFinancialYear = LocalDate.now().getYear - 1
-  private def createManageReportUrl(baseUrl: String, fiId: String, fiName: String) = s"$baseUrl?fiId=$fiId&year=$latestFinancialYear"
+
+  private def latestFinancialYear: Int                             = LocalDate.now().getYear - 1
+  private def createManageReportUrl(baseUrl: String, fiId: String) = s"$baseUrl/manage-reports-for-$latestFinancialYear?fiId=$fiId"
 
   private def getValueContent(name: String, fiIsRegisteredBusiness: Boolean): HtmlContent = {
     val registeredBusinessTag =

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -96,7 +96,7 @@ urls {
   reporting     = "http://localhost:10038/report-for-crs-and-fatca/report/upload-file"
   submissionsResults     = "http://localhost:10038/report-for-crs-and-fatca/report/results-of-submission-checks"
   signOut       = "http://localhost:9553/bas-gateway/sign-out-without-state"
-  manageReport     = "http://localhost:10039/crs-fatca-manual-submission-frontend/read-submission-data"
+  manageReport     = "http://localhost:10039/crs-fatca-manual-submission-frontend"
   lostUTR       = "https://www.gov.uk/find-lost-utr-number"
   searchCrn     = "https://find-and-update.company-information.service.gov.uk/"
   emailEnquiries = "aeoi.enquiries@hmrc.gov.uk"

--- a/test/controllers/YourFinancialInstitutionsControllerSpec.scala
+++ b/test/controllers/YourFinancialInstitutionsControllerSpec.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel
 import views.html.YourFinancialInstitutionsView
 
+import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
 
 class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar with ModelGenerators with ScalaCheckDrivenPropertyChecks {
@@ -83,10 +84,10 @@ class YourFinancialInstitutionsControllerSpec extends SpecBase with MockitoSugar
           running(application) {
             val request = FakeRequest(GET, routes.YourFinancialInstitutionsController.onPageLoad().url)
 
-            val result = route(application, request).value
-
+            val result          = route(application, request).value
+            val year            = LocalDate.now().getYear - 1
             val view            = application.injector.instanceOf[YourFinancialInstitutionsView]
-            val manageReportUrl = s"http://localhost:10039/crs-fatca-manual-submission-frontend/read-submission-data"
+            val manageReportUrl = s"http://localhost:10039/crs-fatca-manual-submission-frontend"
             val institutions =
               YourFinancialInstitutionsViewModel.getYourFinancialInstitutionsRows(Seq(fiDetail.copy(IsFIUser = false)), manageReportUrl)(messages(application))
 

--- a/test/views/YourFinancialInstitutionsViewSpec.scala
+++ b/test/views/YourFinancialInstitutionsViewSpec.scala
@@ -28,13 +28,15 @@ import utils.ViewHelper
 import viewmodels.yourFinancialInstitutions.YourFinancialInstitutionsViewModel
 import views.html.YourFinancialInstitutionsView
 
+import java.time.LocalDate
+
 class YourFinancialInstitutionsViewSpec extends SpecBase with GuiceOneAppPerSuite with Injecting with ViewHelper {
 
-  private val view                                = app.injector.instanceOf[YourFinancialInstitutionsView]
-  private val formProvider                        = new YourFinancialInstitutionsFormProvider()
-  private val form                                = formProvider()
-  private val messagesControllerComponentsForView = app.injector.instanceOf[MessagesControllerComponents]
-
+  private val view                                      = app.injector.instanceOf[YourFinancialInstitutionsView]
+  private val formProvider                              = new YourFinancialInstitutionsFormProvider()
+  private val form                                      = formProvider()
+  private val messagesControllerComponentsForView       = app.injector.instanceOf[MessagesControllerComponents]
+  private val year                                      = LocalDate.now().getYear - 1
   implicit private val request: FakeRequest[AnyContent] = FakeRequest()
   implicit private val messages: Messages               = messagesControllerComponentsForView.messagesApi.preferred(Seq(Lang("en")))
 
@@ -73,7 +75,7 @@ class YourFinancialInstitutionsViewSpec extends SpecBase with GuiceOneAppPerSuit
       getWindowTitle(doc) must include("Manage your financial institutions")
       getPageHeading(doc) mustEqual "You have added 1 financial institution"
       doc.body.select("dt").text() must include("Test Financial Institution")
-      doc.body.select(".govuk-summary-list__actions-list-item").html() must include("baseUrl?fiId=12345")
+      doc.body.select(".govuk-summary-list__actions-list-item").html() must include(s"baseUrl/manage-reports-for-$year?fiId=12345")
     }
   }
 


### PR DESCRIPTION
1. Remove FiName being displayed from manage-your-reports by calling ViewFi from crs-fatca-reporting
2. Remove cache which mean calling readSubmission each time we need past submission data
3. Rename userData to userAnswer
4. Creating FIObj that encapsulates fiName and fiId which can be used in view elections and void journey